### PR TITLE
fix: 修复 UTF-8 字符串截断可能导致 panic 的问题

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -231,11 +231,12 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>) -> Vec<Tool> {
         .iter()
         .filter(|t| !is_unsupported_tool(&t.name))
         .map(|t| {
-            let mut description = t.description.clone();
-            // 限制描述长度为 10000 字符
-            if description.len() > 10000 {
-                description = description[..10000].to_string();
-            }
+            let description = t.description.clone();
+            // 限制描述长度为 10000 字符（安全截断 UTF-8，单次遍历）
+            let description = match description.char_indices().nth(10000) {
+                Some((idx, _)) => description[..idx].to_string(),
+                None => description,
+            };
 
             Tool {
                 tool_specification: ToolSpecification {


### PR DESCRIPTION
## Summary
- 使用 `char_indices().nth()` 替代 `len()` 检查，实现安全的 UTF-8 字符串截断
- 单次遍历即可完成截断，避免多次遍历字符串

## Test plan
- [ ] 验证包含多字节字符的描述正确截断
- [ ] 运行测试套件确保无回归