### PR TITLE
fix: 修复 Codex 审核发现的问题

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -231,10 +231,10 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>) -> Vec<Tool> {
         .iter()
         .filter(|t| !is_unsupported_tool(&t.name))
         .map(|t| {
-            let mut description = t.description.clone();
-            // 限制描述长度为 10000 字符
-            if description.len() > 10000 {
-                description = description[..10000].to_string();
+            let mut description = t.description.clone().unwrap_or_default();
+            // 限制描述长度为 10000 字符（安全截断 UTF-8）
+            if description.chars().count() > 10000 {
+                description = description.chars().take(10000).collect();
             }
 
             Tool {

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -108,6 +108,8 @@ pub struct Message {
 /// 系统消息
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SystemMessage {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub message_type: Option<String>,
     pub text: String,
 }
 
@@ -115,7 +117,8 @@ pub struct SystemMessage {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Tool {
     pub name: String,
-    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub input_schema: HashMap<String, serde_json::Value>,
 }
 


### PR DESCRIPTION
## Summary
- 修复 UTF-8 截断可能导致 panic 的问题，改用 `chars().take()` 安全截断
- 添加 `skip_serializing_if` 属性，避免可选字段序列化为 null
- SystemMessage 添加可选的 message_type 字段
- Tool.description 改为 Option<String> 以支持可选描述

## Test plan
- [ ] 验证序列化输出不包含 null 值
- [ ] 验证多字节字符截断不会 panic
- [ ] 运行测试套件确保无回归