### PR TITLE
machineId 写会文件, 确保服务重启 id不变.    - Cargo.toml: reqwest 切换到 rustls-tls，禁用默认 native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ strip = true
 [dependencies]
 axum = "0.8"
 tokio = { version = "1.0", features = ["full"] }
-reqwest = { version = "0.12", features = ["stream", "json", "socks"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "json", "socks", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"


### PR DESCRIPTION
  feat: 启动时自动补全 machineId 并切换 rustls-tls

  - token_manager: 凭据缺少 machineId 时自动生成并持久化
  - Cargo.toml: reqwest 切换到 rustls-tls，禁用默认 native-tls