### PR TITLE
fix: add placeholder for assistant messages with only tool_use

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -1094,8 +1094,8 @@ mod tests {
             "content 不应为空"
         );
         assert_eq!(
-            result.assistant_response_message.content, "OK",
-            "仅 tool_use 时应使用 'OK' 占位符"
+            result.assistant_response_message.content, "There is a tool use.",
+            "仅 tool_use 时应使用 'There is a tool use.' 占位符"
         );
 
         // 验证 tool_uses 被正确保留


### PR DESCRIPTION
## Summary

When an assistant message contains only `tool_use` blocks (no text or thinking content), the `content` field would be empty. This causes Kiro API to return a **422 error** since it requires non-empty content.

This fix adds `"OK"` as a placeholder when `text_content` is empty but `tool_uses` exist.

## Changes

- Add placeholder logic in `convert_assistant_message()` function
- Add unit tests covering both scenarios:
  - `tool_use` only → should use `"OK"` placeholder
  - `text` + `tool_use` → should use original text

## Test Plan

- [x] Added unit tests for the fix
- [x] Verified with `cargo test`