### PR TITLE
feat: increase request body size limit to 50MB

### DIFF
--- a/src/anthropic/router.rs
+++ b/src/anthropic/router.rs
@@ -1,7 +1,9 @@
 //! Anthropic API 路由配置
 
 use axum::{
-    Router, middleware,
+    Router,
+    extract::DefaultBodyLimit,
+    middleware,
     routing::{get, post},
 };
 
@@ -11,6 +13,9 @@ use super::{
     handlers::{count_tokens, get_models, post_messages},
     middleware::{AppState, auth_middleware, cors_layer},
 };
+
+/// 请求体最大大小限制 (50MB)
+const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 
 /// 创建 Anthropic API 路由
 ///
@@ -55,5 +60,6 @@ pub fn create_router_with_provider(
     Router::new()
         .nest("/v1", v1_routes)
         .layer(cors_layer())
+        .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Axum's default body size limit is too small for large requests (e.g., long conversations with many messages or base64-encoded images). This causes **413 Payload Too Large** errors.

This fix adds `DefaultBodyLimit::max(50MB)` to the Anthropic API router to handle larger payloads.

## Changes

- Add `MAX_BODY_SIZE` constant (50MB) to avoid magic numbers
- Apply `DefaultBodyLimit` layer to the router

## Test Plan

- [x] Verified large requests no longer return 413 errors
- [x] Tested with conversations containing base64-encoded images