### PR TITLE
feat(anthropic): support both string and array format for system field

### DIFF
--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -101,12 +101,68 @@ pub struct MessagesRequest {
     pub messages: Vec<Message>,
     #[serde(default)]
     pub stream: bool,
+    #[serde(default, deserialize_with = "deserialize_system")]
     pub system: Option<Vec<SystemMessage>>,
     pub tools: Option<Vec<Tool>>,
     pub tool_choice: Option<serde_json::Value>,
     pub thinking: Option<Thinking>,
     /// Claude Code 请求中的 metadata，包含 session 信息
     pub metadata: Option<Metadata>,
+}
+
+/// 反序列化 system 字段，支持字符串或数组格式
+fn deserialize_system<'de, D>(deserializer: D) -> Result<Option<Vec<SystemMessage>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    // 创建一个 visitor 来处理 string 或 array
+    struct SystemVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for SystemVisitor {
+        type Value = Option<Vec<SystemMessage>>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or an array of system messages")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Some(vec![SystemMessage {
+                text: value.to_string(),
+            }]))
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut messages = Vec::new();
+            while let Some(msg) = seq.next_element()? {
+                messages.push(msg);
+            }
+            Ok(if messages.is_empty() { None } else { Some(messages) })
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            serde::de::Deserialize::deserialize(deserializer)
+        }
+    }
+
+    deserializer.deserialize_any(SystemVisitor)
 }
 
 /// 消息
@@ -197,7 +253,11 @@ pub struct ImageSource {
 pub struct CountTokensRequest {
     pub model: String,
     pub messages: Vec<Message>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_system"
+    )]
     pub system: Option<Vec<SystemMessage>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,


### PR DESCRIPTION
## 修改内容
- 添加自定义反序列化函数 `deserialize_system`
- 使 `MessagesRequest` 和 `CountTokensRequest` 的 `system` 字段同时支持字符串和数组两种格式

## 原因
Anthropic API 的 system 字段可以接受字符串或数组格式，此修改增加了兼容性。