### PR TITLE
fix: restore is_unsupported_tool function logic

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -327,7 +327,10 @@ fn validate_tool_pairing(history: &[Message], tool_results: &[ToolResult]) -> Ve
             }
             Message::User(user_msg) => {
                 // 收集历史 user 消息中的 tool_results
-                for result in &user_msg.user_input_message.user_input_message_context.tool_results
+                for result in &user_msg
+                    .user_input_message
+                    .user_input_message_context
+                    .tool_results
                 {
                     history_tool_result_ids.insert(result.tool_use_id.clone());
                 }
@@ -405,8 +408,7 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>) -> Vec<Tool> {
 
 /// 检查是否为不支持的工具
 fn is_unsupported_tool(name: &str) -> bool {
-    // matches!(name.to_lowercase().as_str(), "web_search" | "websearch")
-    false
+    matches!(name.to_lowercase().as_str(), "web_search" | "websearch")
 }
 
 /// 生成thinking标签前缀
@@ -905,8 +907,10 @@ mod tests {
 
         // 测试孤立的 tool_use（有 tool_use 但没有对应的 tool_result）
         let mut assistant_msg = AssistantMessage::new("I'll read the file.");
-        assistant_msg = assistant_msg.with_tool_uses(vec![ToolUseEntry::new("tool-orphan", "read")
-            .with_input(serde_json::json!({"path": "/test.txt"}))]);
+        assistant_msg = assistant_msg.with_tool_uses(vec![
+            ToolUseEntry::new("tool-orphan", "read")
+                .with_input(serde_json::json!({"path": "/test.txt"})),
+        ]);
 
         let history = vec![
             Message::User(HistoryUserMessage::new(
@@ -934,8 +938,10 @@ mod tests {
 
         // 测试正常配对的情况
         let mut assistant_msg = AssistantMessage::new("I'll read the file.");
-        assistant_msg = assistant_msg.with_tool_uses(vec![ToolUseEntry::new("tool-1", "read")
-            .with_input(serde_json::json!({"path": "/test.txt"}))]);
+        assistant_msg = assistant_msg.with_tool_uses(vec![
+            ToolUseEntry::new("tool-1", "read")
+                .with_input(serde_json::json!({"path": "/test.txt"})),
+        ]);
 
         let history = vec![
             Message::User(HistoryUserMessage::new(
@@ -995,8 +1001,10 @@ mod tests {
         // 测试历史中已配对的 tool_use 不应该被报告为孤立
         // 场景：多轮对话中，之前的 tool_use 已经在历史中有对应的 tool_result
         let mut assistant_msg1 = AssistantMessage::new("I'll read the file.");
-        assistant_msg1 = assistant_msg1.with_tool_uses(vec![ToolUseEntry::new("tool-1", "read")
-            .with_input(serde_json::json!({"path": "/test.txt"}))]);
+        assistant_msg1 = assistant_msg1.with_tool_uses(vec![
+            ToolUseEntry::new("tool-1", "read")
+                .with_input(serde_json::json!({"path": "/test.txt"})),
+        ]);
 
         // 构建历史中的 user 消息，包含 tool_result
         let mut user_msg_with_result = UserMessage::new("", "claude-sonnet-4.5");
@@ -1038,8 +1046,10 @@ mod tests {
 
         // 测试重复的 tool_result（历史中已配对，当前消息又发送了相同的 tool_result）
         let mut assistant_msg = AssistantMessage::new("I'll read the file.");
-        assistant_msg = assistant_msg.with_tool_uses(vec![ToolUseEntry::new("tool-1", "read")
-            .with_input(serde_json::json!({"path": "/test.txt"}))]);
+        assistant_msg = assistant_msg.with_tool_uses(vec![
+            ToolUseEntry::new("tool-1", "read")
+                .with_input(serde_json::json!({"path": "/test.txt"})),
+        ]);
 
         // 历史中已有 tool_result
         let mut user_msg_with_result = UserMessage::new("", "claude-sonnet-4.5");


### PR DESCRIPTION
## Summary
- Restore the `is_unsupported_tool` function logic that was accidentally commented out
- This fixes the failing `test_is_unsupported_tool` test on master branch
- The function now correctly filters `web_search` and `websearch` tools as documented in README

## Changes
- Uncommented the `matches!` macro in `is_unsupported_tool` function
- Removed the hardcoded `false` return value

## Testing
- All 138 tests pass