### PR TITLE
feat(admin): import token.json credentials

### DIFF
--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -8,6 +8,8 @@ import type {
   SetPriorityRequest,
   AddCredentialRequest,
   AddCredentialResponse,
+  ImportTokenJsonRequest,
+  ImportTokenJsonResponse,
 } from '@/types/api'
 
 // 创建 axios 实例
@@ -82,5 +84,16 @@ export async function addCredential(
 // 删除凭据
 export async function deleteCredential(id: number): Promise<SuccessResponse> {
   const { data } = await api.delete<SuccessResponse>(`/credentials/${id}`)
+  return data
+}
+
+// 批量导入 token.json
+export async function importTokenJson(
+  req: ImportTokenJsonRequest
+): Promise<ImportTokenJsonResponse> {
+  const { data } = await api.post<ImportTokenJsonResponse>(
+    '/credentials/import-token-json',
+    req
+  )
   return data
 }

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { RefreshCw, LogOut, Moon, Sun, Server, Plus } from 'lucide-react'
+import { RefreshCw, LogOut, Moon, Sun, Server, Plus, FileJson } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { storage } from '@/lib/storage'
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { CredentialCard } from '@/components/credential-card'
 import { BalanceDialog } from '@/components/balance-dialog'
 import { AddCredentialDialog } from '@/components/add-credential-dialog'
+import { ImportTokenJsonDialog } from '@/components/import-token-json-dialog'
 import { useCredentials } from '@/hooks/use-credentials'
 
 interface DashboardProps {
@@ -19,6 +20,7 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const [selectedCredentialId, setSelectedCredentialId] = useState<number | null>(null)
   const [balanceDialogOpen, setBalanceDialogOpen] = useState(false)
   const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [darkMode, setDarkMode] = useState(() => {
     if (typeof window !== 'undefined') {
       return document.documentElement.classList.contains('dark')
@@ -144,10 +146,16 @@ export function Dashboard({ onLogout }: DashboardProps) {
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-xl font-semibold">凭据管理</h2>
-            <Button onClick={() => setAddDialogOpen(true)} size="sm">
-              <Plus className="h-4 w-4 mr-2" />
-              添加凭据
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={() => setImportDialogOpen(true)} size="sm">
+                <FileJson className="h-4 w-4 mr-2" />
+                导入 token.json
+              </Button>
+              <Button onClick={() => setAddDialogOpen(true)} size="sm">
+                <Plus className="h-4 w-4 mr-2" />
+                添加凭据
+              </Button>
+            </div>
           </div>
           {data?.credentials.length === 0 ? (
             <Card>
@@ -180,6 +188,12 @@ export function Dashboard({ onLogout }: DashboardProps) {
       <AddCredentialDialog
         open={addDialogOpen}
         onOpenChange={setAddDialogOpen}
+      />
+
+      {/* 导入 token.json 对话框 */}
+      <ImportTokenJsonDialog
+        open={importDialogOpen}
+        onOpenChange={setImportDialogOpen}
       />
     </div>
   )

--- a/admin-ui/src/components/import-token-json-dialog.tsx
+++ b/admin-ui/src/components/import-token-json-dialog.tsx
@@ -1,0 +1,381 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Upload, FileJson, FileUp } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useImportTokenJson } from '@/hooks/use-credentials'
+import { extractErrorMessage } from '@/lib/utils'
+import type { ImportTokenJsonResponse, ImportItemResult, TokenJsonItem } from '@/types/api'
+
+interface ImportTokenJsonDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type Step = 'input' | 'preview' | 'result'
+
+export function ImportTokenJsonDialog({ open, onOpenChange }: ImportTokenJsonDialogProps) {
+  const [step, setStep] = useState<Step>('input')
+  const [jsonInput, setJsonInput] = useState('')
+  const [parsedItems, setParsedItems] = useState<TokenJsonItem[]>([])
+  const [previewResult, setPreviewResult] = useState<ImportTokenJsonResponse | null>(null)
+  const [importResult, setImportResult] = useState<ImportTokenJsonResponse | null>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
+
+  const importMutation = useImportTokenJson()
+
+  const resetState = () => {
+    setStep('input')
+    setJsonInput('')
+    setParsedItems([])
+    setPreviewResult(null)
+    setImportResult(null)
+    setIsDragOver(false)
+  }
+
+  const handleClose = () => {
+    onOpenChange(false)
+    // 延迟重置状态，避免关闭动画时看到状态变化
+    setTimeout(resetState, 200)
+  }
+
+  // 解析 JSON 输入
+  const parseJsonInput = (): TokenJsonItem[] | null => {
+    try {
+      const parsed = JSON.parse(jsonInput.trim())
+      // 支持单个对象或数组
+      if (Array.isArray(parsed)) {
+        return parsed
+      } else if (typeof parsed === 'object' && parsed !== null) {
+        return [parsed]
+      }
+      toast.error('无效的 JSON 格式：需要对象或数组')
+      return null
+    } catch {
+      toast.error('JSON 解析失败：请检查格式是否正确')
+      return null
+    }
+  }
+
+  // 预览（dry-run）
+  const handlePreview = async () => {
+    const items = parseJsonInput()
+    if (!items || items.length === 0) {
+      toast.error('没有可导入的凭据')
+      return
+    }
+
+    setParsedItems(items)
+
+    try {
+      const result = await importMutation.mutateAsync({
+        dryRun: true,
+        items,
+      })
+      setPreviewResult(result)
+      setStep('preview')
+    } catch (error) {
+      toast.error(`预览失败: ${extractErrorMessage(error)}`)
+    }
+  }
+
+  // 确认导入
+  const handleImport = async () => {
+    if (parsedItems.length === 0) return
+
+    try {
+      const result = await importMutation.mutateAsync({
+        dryRun: false,
+        items: parsedItems,
+      })
+      setImportResult(result)
+      setStep('result')
+
+      if (result.summary.added > 0) {
+        toast.success(`成功导入 ${result.summary.added} 个凭据`)
+      }
+    } catch (error) {
+      toast.error(`导入失败: ${extractErrorMessage(error)}`)
+    }
+  }
+
+  // 处理文件读取
+  const readFile = (file: File) => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      const content = event.target?.result as string
+      setJsonInput(content)
+    }
+    reader.onerror = () => {
+      toast.error('文件读取失败')
+    }
+    reader.readAsText(file)
+  }
+
+  // 处理文件上传
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) readFile(file)
+  }
+
+  // 处理拖放
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const file = e.dataTransfer.files?.[0]
+    if (file && file.name.endsWith('.json')) {
+      readFile(file)
+    } else if (file) {
+      toast.error('请上传 .json 文件')
+    }
+  }
+
+  const getActionBadge = (action: ImportItemResult['action']) => {
+    switch (action) {
+      case 'added':
+        return <Badge variant="success">添加</Badge>
+      case 'skipped':
+        return <Badge variant="warning">跳过</Badge>
+      case 'invalid':
+        return <Badge variant="destructive">无效</Badge>
+    }
+  }
+
+  const getResultBadge = (action: ImportItemResult['action']) => {
+    switch (action) {
+      case 'added':
+        return <Badge variant="success">已添加</Badge>
+      case 'skipped':
+        return <Badge variant="warning">已跳过</Badge>
+      case 'invalid':
+        return <Badge variant="destructive">无效</Badge>
+    }
+  }
+
+  // 渲染汇总统计
+  const renderSummary = (data: ImportTokenJsonResponse, isResult: boolean) => {
+    const { summary } = data
+    return (
+      <div className="flex items-center justify-center gap-6 py-4 px-6 bg-muted/50 rounded-lg">
+        <div className="text-center">
+          <div className="text-2xl font-semibold tabular-nums">{summary.parsed}</div>
+          <div className="text-xs text-muted-foreground">解析</div>
+        </div>
+        <div className="h-8 w-px bg-border" />
+        <div className="text-center">
+          <div className="text-2xl font-semibold tabular-nums text-green-600">
+            {summary.added}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {isResult ? '已添加' : '将添加'}
+          </div>
+        </div>
+        <div className="h-8 w-px bg-border" />
+        <div className="text-center">
+          <div className="text-2xl font-semibold tabular-nums text-yellow-600">
+            {summary.skipped}
+          </div>
+          <div className="text-xs text-muted-foreground">跳过</div>
+        </div>
+        <div className="h-8 w-px bg-border" />
+        <div className="text-center">
+          <div className="text-2xl font-semibold tabular-nums text-red-600">
+            {summary.invalid}
+          </div>
+          <div className="text-xs text-muted-foreground">无效</div>
+        </div>
+      </div>
+    )
+  }
+
+  // 渲染项目列表
+  const renderItemList = (items: ImportItemResult[], isResult: boolean) => {
+    if (items.length === 0) {
+      return (
+        <div className="py-8 text-center text-muted-foreground">没有可显示的项目</div>
+      )
+    }
+
+    return (
+      <div className="border rounded-lg overflow-hidden">
+        <div className="max-h-56 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 sticky top-0">
+              <tr>
+                <th className="text-left font-medium px-3 py-2 text-muted-foreground">#</th>
+                <th className="text-left font-medium px-3 py-2 text-muted-foreground">指纹</th>
+                <th className="text-left font-medium px-3 py-2 text-muted-foreground">状态</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {items.map((item) => (
+                <tr key={item.index} className="hover:bg-muted/30 transition-colors">
+                  <td className="px-3 py-2 text-muted-foreground tabular-nums">
+                    {item.index + 1}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div
+                      className="font-mono text-xs truncate max-w-[280px]"
+                      title={item.fingerprint}
+                    >
+                      {item.fingerprint}
+                    </div>
+                    {item.reason && (
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {item.reason}
+                      </div>
+                    )}
+                    {isResult && item.credentialId && (
+                      <div className="text-xs text-green-600 mt-0.5">
+                        ID: #{item.credentialId}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    {isResult ? getResultBadge(item.action) : getActionBadge(item.action)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileJson className="h-5 w-5" />
+            {step === 'input' && '导入 token.json'}
+            {step === 'preview' && '预览导入结果'}
+            {step === 'result' && '导入完成'}
+          </DialogTitle>
+          {step === 'input' && (
+            <DialogDescription>上传或粘贴 token.json 文件内容</DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="flex-1 overflow-auto py-4">
+          {/* Step 1: 输入 */}
+          {step === 'input' && (
+            <div className="space-y-4">
+              {/* 拖放区域 */}
+              <div
+                className={`
+                  relative border-2 border-dashed rounded-lg p-6 text-center transition-colors
+                  ${
+                    isDragOver
+                      ? 'border-primary bg-primary/5'
+                      : 'border-muted-foreground/25 hover:border-muted-foreground/50'
+                  }
+                `}
+                onDragOver={(e) => {
+                  e.preventDefault()
+                  setIsDragOver(true)
+                }}
+                onDragLeave={() => setIsDragOver(false)}
+                onDrop={handleDrop}
+              >
+                <FileUp className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground mb-2">
+                  拖放 token.json 文件到此处
+                </p>
+                <Button variant="outline" size="sm" asChild>
+                  <label htmlFor="file-upload" className="cursor-pointer">
+                    <Upload className="h-4 w-4 mr-2" />
+                    选择文件
+                  </label>
+                </Button>
+                <input
+                  id="file-upload"
+                  type="file"
+                  accept=".json"
+                  onChange={handleFileUpload}
+                  className="hidden"
+                />
+              </div>
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">或粘贴 JSON</span>
+                </div>
+              </div>
+
+              <textarea
+                value={jsonInput}
+                onChange={(e) => setJsonInput(e.target.value)}
+                placeholder='{"refreshToken": "...", "clientId": "...", ...}'
+                className="w-full h-40 p-3 font-mono text-sm border rounded-lg resize-none bg-muted/30 focus:outline-none focus:ring-2 focus:ring-ring focus:bg-background transition-colors"
+              />
+            </div>
+          )}
+
+          {/* Step 2: 预览 */}
+          {step === 'preview' && previewResult && (
+            <div className="space-y-4">
+              {renderSummary(previewResult, false)}
+              {renderItemList(previewResult.items, false)}
+            </div>
+          )}
+
+          {/* Step 3: 结果 */}
+          {step === 'result' && importResult && (
+            <div className="space-y-4">
+              {renderSummary(importResult, true)}
+              {renderItemList(importResult.items, true)}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {step === 'input' && (
+            <>
+              <Button variant="outline" onClick={handleClose}>
+                取消
+              </Button>
+              <Button
+                onClick={handlePreview}
+                disabled={!jsonInput.trim() || importMutation.isPending}
+              >
+                {importMutation.isPending ? '解析中...' : '预览'}
+              </Button>
+            </>
+          )}
+
+          {step === 'preview' && (
+            <>
+              <Button variant="outline" onClick={() => setStep('input')}>
+                返回修改
+              </Button>
+              <Button
+                onClick={handleImport}
+                disabled={importMutation.isPending || previewResult?.summary.added === 0}
+              >
+                {importMutation.isPending
+                  ? '导入中...'
+                  : `确认导入 (${previewResult?.summary.added || 0})`}
+              </Button>
+            </>
+          )}
+
+          {step === 'result' && <Button onClick={handleClose}>完成</Button>}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -7,8 +7,9 @@ import {
   getCredentialBalance,
   addCredential,
   deleteCredential,
+  importTokenJson,
 } from '@/api/credentials'
-import type { AddCredentialRequest } from '@/types/api'
+import type { AddCredentialRequest, ImportTokenJsonRequest } from '@/types/api'
 
 // 查询凭据列表
 export function useCredentials() {
@@ -82,6 +83,20 @@ export function useDeleteCredential() {
     mutationFn: (id: number) => deleteCredential(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
+  })
+}
+
+// 批量导入 token.json
+export function useImportTokenJson() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (req: ImportTokenJsonRequest) => importTokenJson(req),
+    onSuccess: (data) => {
+      // 只有实际添加了凭据时才刷新列表
+      if (data.summary.added > 0) {
+        queryClient.invalidateQueries({ queryKey: ['credentials'] })
+      }
     },
   })
 }

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -67,3 +67,44 @@ export interface AddCredentialResponse {
   message: string
   credentialId: number
 }
+
+// ============ 批量导入 token.json ============
+
+// 官方 token.json 格式
+export interface TokenJsonItem {
+  provider?: string
+  refreshToken?: string
+  clientId?: string
+  clientSecret?: string
+  authMethod?: string
+  priority?: number
+}
+
+// 批量导入请求
+export interface ImportTokenJsonRequest {
+  dryRun: boolean
+  items: TokenJsonItem | TokenJsonItem[]
+}
+
+// 批量导入响应
+export interface ImportTokenJsonResponse {
+  summary: ImportSummary
+  items: ImportItemResult[]
+}
+
+// 导入汇总
+export interface ImportSummary {
+  parsed: number
+  added: number
+  skipped: number
+  invalid: number
+}
+
+// 单项导入结果
+export interface ImportItemResult {
+  index: number
+  fingerprint: string
+  action: 'added' | 'skipped' | 'invalid'
+  reason?: string
+  credentialId?: number
+}

--- a/docs/admin-features-spec.md
+++ b/docs/admin-features-spec.md
@@ -1,0 +1,252 @@
+# Admin 功能增强需求规格
+
+**来源**: https://github.com/hank9999/kiro.rs/issues/35  
+**日期**: 2026-01-15  
+**状态**: 待实现
+
+---
+
+## 概述
+
+在 `/admin` 管理界面增加以下功能：
+1. 官方 token.json 批量导入
+2. 凭证检测（按模型批量验证）
+3. 失效凭证一键删除
+4. 凭证轮训（round-robin）
+
+---
+
+## PR-1: 官方 token.json 批量导入
+
+### 功能描述
+支持以官方 token.json 文件格式进行批量导入凭证。
+
+### 导入规则
+- 按 `provider` 字段判断认证方式：
+  - `BuilderId` → `authMethod = "builder-id"`
+  - `IdC` → `authMethod = "idc"`
+  - `Social` / 空 → `authMethod = "social"`
+  - 其它 provider → 记为 invalid
+- 仅提取"新增凭据"表单字段：
+  - `refreshToken` (必填)
+  - `authMethod` (按 provider 映射)
+  - `clientId` (IdC/BuilderId 需要)
+  - `clientSecret` (IdC/BuilderId 需要)
+  - `priority` (可选，默认 0)
+- 忽略字段：`region`, `machineId`, `accessToken` 等
+
+### token.json 样例结构
+```json
+{
+  "provider": "BuilderId",
+  "refreshToken": "aorAAAAA...",
+  "clientId": "jWC-Ac9XZsJI6NKKyfY4jHVzLWVhc3QtMQ",
+  "clientSecret": "eyJraWQi...",
+  "authMethod": "IdC"
+}
+```
+
+### API 设计
+```
+POST /api/admin/credentials/import-token-json
+Request:
+{
+  "dryRun": boolean,
+  "items": TokenJson | TokenJson[]
+}
+
+Response:
+{
+  "summary": {
+    "parsed": number,
+    "added": number,
+    "skipped": number,
+    "invalid": number
+  },
+  "items": [{
+    "index": number,
+    "fingerprint": string,
+    "action": "added" | "skipped" | "invalid",
+    "reason"?: string
+  }]
+}
+```
+
+### 成功标准
+- [ ] `dryRun=true` 不写盘
+- [ ] `dryRun=false` 写盘结果与 dry-run 报告一致
+- [ ] 响应/日志不包含 token 明文（只返回 fingerprint）
+- [ ] adminApiKey 鉴权正常
+
+### UI 交互
+- Dashboard 增加"导入 token.json"按钮
+- 弹窗：粘贴 JSON / 上传文件
+- 预览：dry-run 结果展示
+- 确认：二次确认后执行导入
+
+---
+
+## PR-2: 凭证检测（按模型批量验证）
+
+### 功能描述
+支持依据所选模型，对勾选的凭证展开批量验证。
+
+### 检测方式
+- 对所选 model 发起最小 probe 请求（真实 API 调用）
+- 不仅仅是 refresh token 成功
+
+### API 设计
+```
+POST /api/admin/credentials/validate
+Request:
+{
+  "credentialIds": number[],
+  "model": string,
+  "timeoutMs"?: number,      // 默认 10000
+  "maxConcurrency"?: number  // 默认 3
+}
+
+Response:
+{
+  "results": [{
+    "credentialId": number,
+    "model": string,
+    "status": "ok" | "denied" | "invalid" | "transient",
+    "detail"?: string,
+    "latencyMs": number
+  }]
+}
+```
+
+### 状态分类
+- `ok`: 验证通过
+- `denied`: 401/403，凭证无权限访问该模型
+- `invalid`: 凭证结构无效或 refresh 失败
+- `transient`: 429/5xx/网络错误（不影响凭证状态）
+
+### 成功标准
+- [ ] 返回每个 credential 的结果
+- [ ] 并发/超时可控
+- [ ] transient 错误不禁用凭证、不影响失败计数
+- [ ] 不依赖外网测试（本地 mock server）
+
+### UI 交互
+- Dashboard 凭证列表增加勾选框
+- 模型下拉选择（sonnet/opus/haiku）
+- "批量检测"按钮
+- 结果展示（状态标签）
+
+---
+
+## PR-3: 失效凭证一键删除
+
+### 功能描述
+实现对所有出现错误的凭证进行一键删除功能。
+
+### 失效判定
+- `disabled == true` 且 `disabled_reason != Manual`
+- 即：自动禁用的凭证（TooManyFailures / QuotaExceeded）
+- 手动禁用的凭证不会被删除
+
+### API 设计
+```
+POST /api/admin/credentials/bulk-delete-invalid
+Request:
+{
+  "dryRun": boolean
+}
+
+Response:
+{
+  "matched": number,
+  "deleted": number,
+  "ids": number[]
+}
+```
+
+### 成功标准
+- [ ] dry-run 列表与实际删除一致
+- [ ] 手动禁用的凭证不会被删除
+- [ ] UI 必须二次确认
+
+### UI 交互
+- Dashboard 增加"一键删除失效"按钮
+- 点击后先 dry-run 预览
+- 展示将删除的凭证列表
+- 二次确认后执行删除
+
+---
+
+## PR-4: 凭证轮训（Round-Robin）
+
+### 功能描述
+提供凭证轮训功能，管理端所有未禁用的凭证进行轮流调用。
+
+### 行为定义
+- 开启轮训后：所有未禁用凭证轮流调用
+- 优先级不再作为选择顺序（仅作为展示字段）
+- 默认保持当前 priority 模式
+
+### 配置
+```json
+// config.json
+{
+  "credentialRotation": "priority" | "roundRobin"
+}
+```
+
+### API 设计
+```
+GET /api/admin/settings
+Response:
+{
+  "credentialRotation": "priority" | "roundRobin"
+}
+
+POST /api/admin/settings
+Request:
+{
+  "credentialRotation": "priority" | "roundRobin"
+}
+Response:
+{
+  "success": true,
+  "message": "设置已更新并立即生效"
+}
+```
+
+### 生效方式
+- **立即生效**：运行期更新 `MultiTokenManager`，并同步写回 config.json
+- 无需重启
+
+### 成功标准
+- [ ] 默认行为不变（priority 模式）
+- [ ] 轮训开启后请求分布可观测
+- [ ] 线程安全（并发下游标正确）
+- [ ] /admin 开关可切换并写回配置
+
+### UI 交互
+- Dashboard 增加"凭证选择策略"设置区域
+- 下拉选择：优先级模式 / 轮训模式
+- 切换后立即生效
+
+---
+
+## 实现顺序
+
+1. **PR-1**: 官方 token.json 批量导入
+2. **PR-2**: 凭证检测（按模型批量验证）
+3. **PR-3**: 失效凭证一键删除
+4. **PR-4**: 凭证轮训
+
+每个 PR 为独立分支，包含完整的后端 + 前端实现。
+
+---
+
+## 技术约束
+
+- 后端：Rust (Axum)，遵循现有 `src/admin/*` 模式
+- 前端：React + TypeScript + Tailwind，遵循现有 `admin-ui/src/*` 模式
+- 所有新 endpoint 必须经过 adminApiKey 鉴权
+- 响应/日志不得包含 token 明文
+- 使用 camelCase JSON 字段命名

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -8,7 +8,10 @@ use axum::{
 
 use super::{
     middleware::AdminState,
-    types::{AddCredentialRequest, SetDisabledRequest, SetPriorityRequest, SuccessResponse},
+    types::{
+        AddCredentialRequest, ImportTokenJsonRequest, SetDisabledRequest, SetPriorityRequest,
+        SuccessResponse,
+    },
 };
 
 /// GET /api/admin/credentials
@@ -99,6 +102,18 @@ pub async fn delete_credential(
 ) -> impl IntoResponse {
     match state.service.delete_credential(id) {
         Ok(_) => Json(SuccessResponse::new(format!("凭据 #{} 已删除", id))).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// POST /api/admin/credentials/import-token-json
+/// 批量导入 token.json
+pub async fn import_token_json(
+    State(state): State<AdminState>,
+    Json(payload): Json<ImportTokenJsonRequest>,
+) -> impl IntoResponse {
+    match state.service.import_token_json(payload).await {
+        Ok(response) => Json(response).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
 }

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -8,7 +8,7 @@ use axum::{
 use super::{
     handlers::{
         add_credential, delete_credential, get_all_credentials, get_credential_balance,
-        reset_failure_count, set_credential_disabled, set_credential_priority,
+        import_token_json, reset_failure_count, set_credential_disabled, set_credential_priority,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -23,6 +23,7 @@ use super::{
 /// - `POST /credentials/:id/priority` - 设置凭据优先级
 /// - `POST /credentials/:id/reset` - 重置失败计数
 /// - `GET /credentials/:id/balance` - 获取凭据余额
+/// - `POST /credentials/import-token-json` - 批量导入 token.json
 ///
 /// # 认证
 /// 需要 Admin API Key 认证，支持：
@@ -34,6 +35,7 @@ pub fn create_admin_router(state: AdminState) -> Router {
             "/credentials",
             get(get_all_credentials).post(add_credential),
         )
+        .route("/credentials/import-token-json", post(import_token_json))
         .route("/credentials/{id}", delete(delete_credential))
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))


### PR DESCRIPTION
## Summary
Add token.json bulk import feature for Admin API and UI

is hank9999/kiro.rs#35

## Changes
### Backend
- `src/admin/types.rs`: Import request/response types
- `src/admin/service.rs`: Import logic with fingerprint hashing, provider-based authMethod mapping
- `src/admin/handlers.rs`: Import handler
- `src/admin/router.rs`: Route registration

### Frontend
- `admin-ui/src/types/api.ts`: Import types
- `admin-ui/src/api/credentials.ts`: Import API call
- `admin-ui/src/hooks/use-credentials.ts`: Import hook
- `admin-ui/src/components/dashboard.tsx`: Import button and dialog
- `admin-ui/src/components/import-token-json-dialog.tsx`: New dialog component

## Features
- New endpoint: `POST /api/admin/credentials/import-token-json`
- Dry-run preview before actual import
- Provider-based authMethod mapping (unknown provider → invalid)
- Fingerprint-based duplicate detection

## Testing
- All 138 tests pass