### PR TITLE
fix(websearch): 修复搜索摘要截断中文时 panic 的 UTF-8 边界问题

### DIFF
--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -420,11 +420,10 @@ fn generate_search_summary(query: &str, results: &Option<WebSearchResults>) -> S
         for (i, result) in results.results.iter().enumerate() {
             summary.push_str(&format!("{}. **{}**\n", i + 1, result.title));
             if let Some(ref snippet) = result.snippet {
-                // 截断过长的摘要
-                let truncated = if snippet.len() > 200 {
-                    format!("{}...", &snippet[..200])
-                } else {
-                    snippet.clone()
+                // 截断过长的摘要（安全处理 UTF-8 多字节字符）
+                let truncated = match snippet.char_indices().nth(200) {
+                    Some((idx, _)) => format!("{}...", &snippet[..idx]),
+                    None => snippet.clone(),
                 };
                 summary.push_str(&format!("   {}\n", truncated));
             }


### PR DESCRIPTION
## 问题

`snippet[..200]` 按字节截断，遇到中文等多字节 UTF-8 字符时会在字符中间截断，导致 `panic: byte index is not a char boundary`。

## 修复

改用 `char_indices().nth(200)` 按字符边界安全截断。

## 改动范围

- `src/anthropic/websearch.rs`: 1 处截断逻辑