### PR TITLE
fix(handlers): 限制 max_tokens 最大值为 32000

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -120,6 +120,17 @@ pub async fn post_messages(
     State(state): State<AppState>,
     JsonExtractor(mut payload): JsonExtractor<MessagesRequest>,
 ) -> Response {
+    // 限制 max_tokens 最大值为 32000（Kiro 上游限制）
+    const MAX_TOKENS_LIMIT: i32 = 32000;
+    if payload.max_tokens > MAX_TOKENS_LIMIT {
+        tracing::warn!(
+            original = payload.max_tokens,
+            adjusted = MAX_TOKENS_LIMIT,
+            "max_tokens 超出上游限制，已自动调整"
+        );
+        payload.max_tokens = MAX_TOKENS_LIMIT;
+    }
+
     tracing::info!(
         model = %payload.model,
         max_tokens = %payload.max_tokens,


### PR DESCRIPTION
## 问题

客户端可能发送 `max_tokens` 超过 32000 的请求（如 Claude Code 默认 128000），Kiro 上游会直接拒绝。

## 修复

在请求处理入口自动将超限的 `max_tokens` 调整为 32000，并记录警告日志。

## 改动范围

- `src/anthropic/handlers.rs`: `post_messages` 函数入口添加限制逻辑