### PR TITLE
feat: 添加 sensitive-logs feature flag 控制敏感日志输出

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 lto = true
 strip = true
 
+[features]
+sensitive-logs = []  # 启用后输出完整请求/响应体日志（仅用于调试）
+
 [dependencies]
 axum = "0.8"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -203,7 +203,10 @@ pub async fn post_messages(
         }
     };
 
+    #[cfg(feature = "sensitive-logs")]
     tracing::debug!("Kiro request body: {}", request_body);
+    #[cfg(not(feature = "sensitive-logs"))]
+    tracing::debug!(kiro_request_body_bytes = request_body.len(), "已构建 Kiro 请求体");
 
     // 估算输入 tokens
     let input_tokens = token::count_all_tokens(
@@ -703,7 +706,10 @@ pub async fn post_messages_cc(
         }
     };
 
+    #[cfg(feature = "sensitive-logs")]
     tracing::debug!("Kiro request body: {}", request_body);
+    #[cfg(not(feature = "sensitive-logs"))]
+    tracing::debug!(kiro_request_body_bytes = request_body.len(), "已构建 Kiro 请求体");
 
     // 估算输入 tokens
     let input_tokens = token::count_all_tokens(


### PR DESCRIPTION
## 动机

生产环境中 `tracing::debug` 输出完整 Kiro 请求体可能泄露用户对话内容。

## 实现

- 在 `Cargo.toml` 中添加 `sensitive-logs` feature flag
- 默认不输出完整请求体（仅记录字节数）
- 启用 feature 后才输出完整内容

```bash
# 调试构建
cargo build --features sensitive-logs
```

## 改动范围

- `Cargo.toml`: 添加 feature 定义
- `src/anthropic/handlers.rs`: 2 处请求体日志改为条件编译