### PR TITLE
fix(handlers): 空 tool input 不再触发 JSON 解析告警

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -457,14 +457,18 @@ async fn handle_non_stream_request(
 
                             // 如果是完整的工具调用，添加到列表
                             if tool_use.stop {
-                                let input: serde_json::Value = serde_json::from_str(buffer)
-                                    .unwrap_or_else(|e| {
-                                        tracing::warn!(
-                                            "工具输入 JSON 解析失败: {}, tool_use_id: {}, 原始内容: {}",
-                                            e, tool_use.tool_use_id, buffer
-                                        );
-                                        serde_json::json!({})
-                                    });
+                                let input: serde_json::Value = if buffer.is_empty() {
+                                    serde_json::json!({})
+                                } else {
+                                    serde_json::from_str(buffer)
+                                        .unwrap_or_else(|e| {
+                                            tracing::warn!(
+                                                "工具输入 JSON 解析失败: {}, tool_use_id: {}",
+                                                e, tool_use.tool_use_id
+                                            );
+                                            serde_json::json!({})
+                                        })
+                                };
 
                                 tool_uses.push(json!({
                                     "type": "tool_use",


### PR DESCRIPTION
## 问题

无参数工具的 input 为空字符串，`serde_json::from_str("")` 会解析失败并输出 warn 日志，造成日志噪音。

## 修复

空 buffer 直接返回 `{}`，跳过 JSON 解析。同时移除日志中的原始内容输出，避免泄露敏感信息。

## 改动范围

- `src/anthropic/handlers.rs`: tool input 解析逻辑添加空值检查