### PR TITLE
feat: 添加流量监控模块

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 /admin-ui/pnpm-lock.yaml
 /admin-ui/package-lock.json
 /admin-ui/tsconfig.tsbuildinfo
-/credentials.*
-/kiro_balance_cache.json
-/kiro_stats.json
+*/credentials.*
+*/kiro_balance_cache.json
+*/kiro_stats.json
+/config/*
+.omc/*
+.ace-tool/
+.tmp/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ parking_lot = "0.12"  # 高性能同步原语
 subtle = "2.6"        # 常量时间比较（防止时序攻击）
 rust-embed = "8"      # 嵌入静态文件
 mime_guess = "2"      # MIME 类型推断
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -4,11 +4,13 @@ import { LoginPage } from '@/components/login-page'
 import { Dashboard } from '@/components/dashboard'
 import { Toaster } from '@/components/ui/sonner'
 
+export type PageType = 'credentials' | 'flows'
+
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [currentPage, setCurrentPage] = useState<PageType>('credentials')
 
   useEffect(() => {
-    // 检查是否已经有保存的 API Key
     if (storage.getApiKey()) {
       setIsLoggedIn(true)
     }
@@ -25,7 +27,11 @@ function App() {
   return (
     <>
       {isLoggedIn ? (
-        <Dashboard onLogout={handleLogout} />
+        <Dashboard
+          onLogout={handleLogout}
+          currentPage={currentPage}
+          onPageChange={setCurrentPage}
+        />
       ) : (
         <LoginPage onLogin={handleLogin} />
       )}

--- a/admin-ui/src/api/flows.ts
+++ b/admin-ui/src/api/flows.ts
@@ -1,0 +1,58 @@
+import axios from 'axios'
+import { storage } from '@/lib/storage'
+import type {
+  FlowListResponse,
+  FlowStatsResponse,
+  FlowQuery,
+  SuccessResponse,
+} from '@/types/api'
+
+// 创建 axios 实例（复用与 credentials 相同的模式）
+const api = axios.create({
+  baseURL: '/api/admin',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// 请求拦截器添加 API Key
+api.interceptors.request.use((config) => {
+  const apiKey = storage.getApiKey()
+  if (apiKey) {
+    config.headers['x-api-key'] = apiKey
+  }
+  return config
+})
+
+// 获取流量记录列表
+export async function getFlows(query: FlowQuery): Promise<FlowListResponse> {
+  const { data } = await api.get<FlowListResponse>('/flows', { params: query })
+  return data
+}
+
+// 获取流量统计
+export async function getFlowStats(): Promise<FlowStatsResponse> {
+  const { data } = await api.get<FlowStatsResponse>('/flows/stats')
+  return data
+}
+
+// 清空流量记录
+export async function clearFlows(before?: string): Promise<SuccessResponse> {
+  const params = before ? { before } : undefined
+  const { data } = await api.delete<SuccessResponse>('/flows', { params })
+  return data
+}
+
+// 检查流量监控是否可用
+export async function checkFlowMonitorAvailable(): Promise<boolean> {
+  try {
+    await api.get('/flows/stats')
+    return true
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return false
+    }
+    // Non-404 errors (auth, network, server) — assume feature exists
+    return true
+  }
+}

--- a/admin-ui/src/components/flow-monitor.tsx
+++ b/admin-ui/src/components/flow-monitor.tsx
@@ -1,0 +1,313 @@
+import { useState } from 'react'
+import { Activity, Zap, Clock, AlertTriangle, Trash2, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
+import { useFlows, useFlowStats, useClearFlows } from '@/hooks/use-flows'
+import type { FlowQuery } from '@/types/api'
+
+function formatTokens(n: number | null | undefined) {
+  if (n == null) return '-'
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
+  return n.toString()
+}
+
+function formatDuration(ms: number) {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${ms}ms`
+}
+
+function formatTime(ts: string) {
+  try {
+    const d = new Date(ts)
+    return d.toLocaleString('zh-CN', { hour12: false })
+  } catch {
+    return ts
+  }
+}
+
+export function FlowMonitor() {
+  const [query, setQuery] = useState<FlowQuery>({ page: 1, pageSize: 20 })
+  const [modelFilter, setModelFilter] = useState<string>('')
+  const [statusFilter, setStatusFilter] = useState<'' | 'success' | 'error'>('')
+  const [clearDialogOpen, setClearDialogOpen] = useState(false)
+
+  const { data: flowsData, isLoading: flowsLoading, error: flowsError, refetch: refetchFlows } = useFlows({
+    ...query,
+    model: modelFilter || undefined,
+    status: statusFilter || undefined,
+  })
+  const { data: stats, isLoading: statsLoading, error: statsError } = useFlowStats()
+  const { mutate: clearFlowsMutation, isPending: clearing } = useClearFlows()
+
+  const handleClear = () => {
+    setClearDialogOpen(true)
+  }
+
+  const handleConfirmClear = () => {
+    setClearDialogOpen(false)
+    clearFlowsMutation(undefined, {
+      onSuccess: () => toast.success('已清空流量记录'),
+      onError: (e) => toast.error(`清空失败: ${(e as Error).message}`),
+    })
+  }
+
+  const handlePageChange = (newPage: number) => {
+    setQuery(prev => ({ ...prev, page: newPage }))
+  }
+
+  const totalPages = flowsData ? Math.ceil(flowsData.total / (query.pageSize || 20)) : 0
+
+  return (
+    <div className="space-y-6">
+      {/* 统计卡片 */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Activity className="h-4 w-4" />
+              总请求数
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {statsLoading ? '...' : formatTokens(stats?.totalRequests)}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Zap className="h-4 w-4" />
+              总 Token 用量
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {statsLoading ? '...' : formatTokens(stats?.totalTokens)}
+            </div>
+            {stats && (
+              <p className="text-xs text-muted-foreground mt-1">
+                入 {formatTokens(stats.totalInputTokens)} / 出 {formatTokens(stats.totalOutputTokens)}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Clock className="h-4 w-4" />
+              平均延迟
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {statsLoading ? '...' : stats ? formatDuration(stats.avgDurationMs) : '-'}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4" />
+              错误率
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {statsLoading ? '...' : stats ? `${(stats.errorRate * 100).toFixed(1)}%` : '-'}
+            </div>
+            {stats && stats.errorCount > 0 && (
+              <p className="text-xs text-red-500 mt-1">{stats.errorCount} 个错误</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 模型用量分布 */}
+      {stats && stats.models.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">模型用量分布</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {stats.models.map((m) => (
+                <Badge
+                  key={m.model}
+                  variant={modelFilter === m.model ? 'default' : 'secondary'}
+                  className="cursor-pointer"
+                  onClick={() => {
+                    setModelFilter(modelFilter === m.model ? '' : m.model)
+                    setQuery(prev => ({ ...prev, page: 1 }))
+                  }}
+                >
+                  {m.model}: {m.count} 次 · {formatTokens(m.totalInputTokens + m.totalOutputTokens)} tokens
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 过滤器和操作栏 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="text-xl font-semibold">流量记录</h2>
+          <div className="flex gap-1">
+            {(['', 'success', 'error'] as const).map((s) => (
+              <Button
+                key={s}
+                size="sm"
+                variant={statusFilter === s ? 'default' : 'ghost'}
+                onClick={() => {
+                  setStatusFilter(s)
+                  setQuery(prev => ({ ...prev, page: 1 }))
+                }}
+              >
+                {s === '' ? '全部' : s === 'success' ? '成功' : '错误'}
+              </Button>
+            ))}
+          </div>
+          {modelFilter && (
+            <Badge variant="outline" className="cursor-pointer" onClick={() => { setModelFilter(''); setQuery(prev => ({ ...prev, page: 1 })) }}>
+              模型: {modelFilter} ✕
+            </Badge>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={() => refetchFlows()}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            刷新
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="text-destructive hover:text-destructive"
+            onClick={handleClear}
+            disabled={clearing}
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            清空日志
+          </Button>
+        </div>
+      </div>
+
+      {/* 流量记录表格 */}
+      <Card>
+        <CardContent className="p-0">
+          {flowsLoading ? (
+            <div className="p-8 text-center text-muted-foreground">加载中...</div>
+          ) : flowsError || statsError ? (
+            <div className="p-8 text-center text-muted-foreground">流量监控不可用</div>
+          ) : !flowsData || flowsData.records.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">暂无流量记录</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left p-3 font-medium">时间</th>
+                    <th className="text-left p-3 font-medium">模型</th>
+                    <th className="text-left p-3 font-medium">路径</th>
+                    <th className="text-right p-3 font-medium">Token (入/出)</th>
+                    <th className="text-right p-3 font-medium">延迟</th>
+                    <th className="text-center p-3 font-medium">状态</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {flowsData.records.map((record) => (
+                    <tr
+                      key={record.id}
+                      className={`border-b hover:bg-muted/30 ${record.statusCode >= 400 ? 'bg-red-50 dark:bg-red-950/20' : ''}`}
+                    >
+                      <td className="p-3 whitespace-nowrap text-muted-foreground">
+                        {formatTime(record.timestamp)}
+                      </td>
+                      <td className="p-3">
+                        <Badge variant="outline" className="font-mono text-xs">
+                          {record.model}
+                        </Badge>
+                        {record.stream && (
+                          <Badge variant="secondary" className="ml-1 text-xs">流式</Badge>
+                        )}
+                      </td>
+                      <td className="p-3 font-mono text-xs text-muted-foreground">
+                        {record.path}
+                      </td>
+                      <td className="p-3 text-right font-mono text-xs">
+                        {formatTokens(record.inputTokens)} / {formatTokens(record.outputTokens)}
+                      </td>
+                      <td className="p-3 text-right font-mono text-xs">
+                        {formatDuration(record.durationMs)}
+                      </td>
+                      <td className="p-3 text-center">
+                        {record.statusCode >= 400 ? (
+                          <Badge variant="destructive" className="text-xs" title={record.error || undefined}>
+                            {record.statusCode}
+                          </Badge>
+                        ) : (
+                          <Badge variant="success" className="text-xs">
+                            {record.statusCode}
+                          </Badge>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 分页 */}
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center gap-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(Math.max(1, (query.page || 1) - 1))}
+            disabled={(query.page || 1) <= 1}
+          >
+            上一页
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            第 {query.page || 1} / {totalPages} 页（共 {flowsData?.total || 0} 条记录）
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(Math.min(totalPages, (query.page || 1) + 1))}
+            disabled={(query.page || 1) >= totalPages}
+          >
+            下一页
+          </Button>
+        </div>
+      )}
+
+      {/* 清空确认对话框 */}
+      <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>确认清空</DialogTitle>
+            <DialogDescription>
+              确定要清空所有流量记录吗？此操作无法撤销。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setClearDialogOpen(false)}>
+              取消
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmClear} disabled={clearing}>
+              确认清空
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/admin-ui/src/hooks/use-flows.ts
+++ b/admin-ui/src/hooks/use-flows.ts
@@ -1,0 +1,44 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getFlows, getFlowStats, clearFlows, checkFlowMonitorAvailable } from '@/api/flows'
+import type { FlowQuery } from '@/types/api'
+
+// 查询流量记录
+export function useFlows(query: FlowQuery) {
+  return useQuery({
+    queryKey: ['flows', query],
+    queryFn: () => getFlows(query),
+    refetchInterval: 10000, // 每 10 秒刷新
+  })
+}
+
+// 查询流量统计
+export function useFlowStats() {
+  return useQuery({
+    queryKey: ['flowStats'],
+    queryFn: getFlowStats,
+    refetchInterval: 30000, // 每 30 秒刷新
+  })
+}
+
+// 清空流量记录
+export function useClearFlows() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (before?: string) => clearFlows(before),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['flows'] })
+      queryClient.invalidateQueries({ queryKey: ['flowStats'] })
+    },
+  })
+}
+
+// 检查流量监控是否可用
+export function useFlowMonitorAvailable() {
+  return useQuery({
+    queryKey: ['flowMonitorAvailable'],
+    queryFn: checkFlowMonitorAvailable,
+    staleTime: 60000,
+    retry: 1,
+    retryDelay: 3000,
+  })
+}

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -74,3 +74,56 @@ export interface AddCredentialResponse {
   credentialId: number
   email?: string
 }
+
+// ===== Flow Monitor 类型 =====
+
+export interface FlowRecord {
+  id: number
+  requestId: string
+  timestamp: string
+  path: string
+  model: string
+  stream: boolean
+  inputTokens: number | null
+  outputTokens: number | null
+  totalTokens: number | null
+  durationMs: number
+  statusCode: number
+  error: string | null
+  userId: string | null
+}
+
+export interface FlowListResponse {
+  total: number
+  page: number
+  pageSize: number
+  records: FlowRecord[]
+}
+
+export interface FlowStatsResponse {
+  totalRequests: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalTokens: number
+  avgDurationMs: number
+  errorCount: number
+  errorRate: number
+  models: ModelStats[]
+}
+
+export interface ModelStats {
+  model: string
+  count: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  avgDurationMs: number
+}
+
+export interface FlowQuery {
+  page?: number
+  pageSize?: number
+  model?: string
+  status?: 'success' | 'error'
+  startTime?: string
+  endTime?: string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     ports:
       - "127.0.0.1:8990:8990"
     volumes:
-      - ./config.json:/app/config/config.json:ro
-      - ./credentials.json:/app/config/credentials.json
+      - ./config/config.json:/app/config/config.json:ro
+      - ./config/credentials.json:/app/config/credentials.json
     restart: unless-stopped

--- a/src/anthropic/middleware.rs
+++ b/src/anthropic/middleware.rs
@@ -12,6 +12,7 @@ use axum::{
 
 use crate::common::auth;
 use crate::kiro::provider::KiroProvider;
+use crate::flow_monitor::FlowMonitor;
 
 use super::types::ErrorResponse;
 
@@ -25,6 +26,7 @@ pub struct AppState {
     pub kiro_provider: Option<Arc<KiroProvider>>,
     /// Profile ARN（可选，用于请求）
     pub profile_arn: Option<String>,
+    pub flow_monitor: Option<Arc<FlowMonitor>>,
 }
 
 impl AppState {
@@ -34,6 +36,7 @@ impl AppState {
             api_key: api_key.into(),
             kiro_provider: None,
             profile_arn: None,
+            flow_monitor: None,
         }
     }
 
@@ -46,6 +49,12 @@ impl AppState {
     /// 设置 Profile ARN
     pub fn with_profile_arn(mut self, arn: impl Into<String>) -> Self {
         self.profile_arn = Some(arn.into());
+        self
+    }
+
+    /// 设置 FlowMonitor
+    pub fn with_flow_monitor(mut self, monitor: Arc<FlowMonitor>) -> Self {
+        self.flow_monitor = Some(monitor);
         self
     }
 }

--- a/src/anthropic/router.rs
+++ b/src/anthropic/router.rs
@@ -7,6 +7,8 @@ use axum::{
     routing::{get, post},
 };
 
+use std::sync::Arc;
+use crate::flow_monitor::FlowMonitor;
 use crate::kiro::provider::KiroProvider;
 
 use super::{
@@ -38,6 +40,7 @@ pub fn create_router_with_provider(
     api_key: impl Into<String>,
     kiro_provider: Option<KiroProvider>,
     profile_arn: Option<String>,
+    flow_monitor: Option<Arc<FlowMonitor>>,
 ) -> Router {
     let mut state = AppState::new(api_key);
     if let Some(provider) = kiro_provider {
@@ -45,6 +48,9 @@ pub fn create_router_with_provider(
     }
     if let Some(arn) = profile_arn {
         state = state.with_profile_arn(arn);
+    }
+    if let Some(monitor) = flow_monitor {
+        state = state.with_flow_monitor(monitor);
     }
 
     // 需要认证的 /v1 路由

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -1077,7 +1077,7 @@ impl StreamContext {
 /// 4. 一次性返回所有事件
 pub struct BufferedStreamContext {
     /// 内部流处理上下文（复用现有的事件处理逻辑）
-    inner: StreamContext,
+    pub inner: StreamContext,
     /// 缓冲的所有事件（包括 message_start、content_block_start 等）
     event_buffer: Vec<SseEvent>,
     /// 估算的 input_tokens（用于回退）

--- a/src/flow_monitor/handlers.rs
+++ b/src/flow_monitor/handlers.rs
@@ -1,0 +1,114 @@
+//! Flow Monitor API 处理器
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+
+use super::router::FlowMonitorState;
+use super::types::FlowQuery;
+
+/// GET /api/admin/flows
+pub async fn get_flows(
+    State(state): State<FlowMonitorState>,
+    Query(query): Query<FlowQuery>,
+) -> impl IntoResponse {
+    // 校验时间格式
+    if let Some(ref t) = query.start_time {
+        if chrono::DateTime::parse_from_rfc3339(t).is_err() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {"type": "invalid_request_error", "message": format!("无效的 startTime 格式，需要 RFC3339 格式: {}", t)}
+                })),
+            ).into_response();
+        }
+    }
+    if let Some(ref t) = query.end_time {
+        if chrono::DateTime::parse_from_rfc3339(t).is_err() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {"type": "invalid_request_error", "message": format!("无效的 endTime 格式，需要 RFC3339 格式: {}", t)}
+                })),
+            ).into_response();
+        }
+    }
+    match state.monitor.query(query).await {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => {
+            tracing::error!("查询流量记录失败: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": {"type": "internal_error", "message": format!("查询失败: {}", e)}
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// GET /api/admin/flows/stats
+pub async fn get_flow_stats(
+    State(state): State<FlowMonitorState>,
+) -> impl IntoResponse {
+    match state.monitor.get_stats().await {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => {
+            tracing::error!("获取流量统计失败: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": {"type": "internal_error", "message": format!("统计失败: {}", e)}
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// DELETE /api/admin/flows 查询参数
+#[derive(serde::Deserialize)]
+pub struct ClearFlowsQuery {
+    pub before: Option<String>,
+}
+
+/// DELETE /api/admin/flows
+pub async fn clear_flows(
+    State(state): State<FlowMonitorState>,
+    Query(query): Query<ClearFlowsQuery>,
+) -> impl IntoResponse {
+    let before = query.before;
+
+    // 校验 before 时间格式
+    if let Some(ref before_str) = before {
+        if chrono::DateTime::parse_from_rfc3339(before_str).is_err() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {"type": "invalid_request_error", "message": format!("无效的时间格式，需要 RFC3339 格式: {}", before_str)}
+                })),
+            ).into_response();
+        }
+    }
+
+    match state.monitor.clear(before).await {
+        Ok(count) => Json(serde_json::json!({
+            "success": true,
+            "message": format!("已清除 {} 条记录", count)
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::error!("清空流量记录失败: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": {"type": "internal_error", "message": format!("清空失败: {}", e)}
+                })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/src/flow_monitor/mod.rs
+++ b/src/flow_monitor/mod.rs
@@ -1,0 +1,12 @@
+//! LLM 流量监控模块
+//!
+//! 提供请求/响应拦截、持久化存储和查询功能
+
+pub mod model;
+pub mod store;
+mod handlers;
+mod router;
+mod types;
+
+pub use store::FlowMonitor;
+pub use router::create_flow_monitor_router;

--- a/src/flow_monitor/model.rs
+++ b/src/flow_monitor/model.rs
@@ -1,0 +1,21 @@
+//! 流量记录数据模型
+
+use serde::Serialize;
+
+/// 流量记录
+#[derive(Debug, Clone, Serialize)]
+pub struct FlowRecord {
+    pub id: i64,
+    pub request_id: String,
+    pub timestamp: String,
+    pub method: String,
+    pub path: String,
+    pub model: String,
+    pub stream: bool,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub duration_ms: i64,
+    pub status_code: u16,
+    pub error: Option<String>,
+    pub user_id: Option<String>,
+}

--- a/src/flow_monitor/router.rs
+++ b/src/flow_monitor/router.rs
@@ -1,0 +1,67 @@
+//! Flow Monitor API 路由
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Json},
+    routing::get,
+    Router,
+};
+
+use crate::common::auth;
+
+use super::handlers::{clear_flows, get_flow_stats, get_flows};
+use super::store::FlowMonitor;
+
+/// Flow Monitor API 状态
+#[derive(Clone)]
+pub struct FlowMonitorState {
+    pub admin_api_key: String,
+    pub monitor: Arc<FlowMonitor>,
+}
+
+/// Flow Monitor 认证中间件
+async fn flow_auth_middleware(
+    State(state): State<FlowMonitorState>,
+    request: Request<Body>,
+    next: Next,
+) -> axum::response::Response {
+    match auth::extract_api_key(&request) {
+        Some(key) if auth::constant_time_eq(&key, &state.admin_api_key) => {
+            next.run(request).await
+        }
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": {"type": "authentication_error", "message": "Invalid API key"}
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// 创建 Flow Monitor API 路由
+///
+/// 返回 Router<()>，可直接 nest 到主应用
+pub fn create_flow_monitor_router(
+    admin_api_key: impl Into<String>,
+    monitor: Arc<FlowMonitor>,
+) -> Router {
+    let state = FlowMonitorState {
+        admin_api_key: admin_api_key.into(),
+        monitor,
+    };
+
+    Router::new()
+        .route("/flows", get(get_flows).delete(clear_flows))
+        .route("/flows/stats", get(get_flow_stats))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            flow_auth_middleware,
+        ))
+        .with_state(state)
+}

--- a/src/flow_monitor/store.rs
+++ b/src/flow_monitor/store.rs
@@ -1,0 +1,292 @@
+//! 流量监控存储和异步服务
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use chrono::Utc;
+use rusqlite::Connection;
+use tokio::sync::mpsc;
+
+use super::model::FlowRecord;
+use super::types::{FlowQuery, FlowStatsResponse, ModelStats, FlowListResponse, FlowRecordResponse};
+
+/// 底层 SQLite 存储（同步）
+struct FlowStore {
+    conn: std::sync::Mutex<Connection>,
+}
+
+impl FlowStore {
+    fn new(db_path: &str) -> Result<Self> {
+        let conn = Connection::open(db_path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS flow_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                method TEXT NOT NULL DEFAULT 'POST',
+                path TEXT NOT NULL,
+                model TEXT NOT NULL,
+                stream INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                status_code INTEGER NOT NULL DEFAULT 200,
+                error TEXT,
+                user_id TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_flow_timestamp ON flow_records(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_flow_model ON flow_records(model);
+            CREATE INDEX IF NOT EXISTS idx_flow_status ON flow_records(status_code);",
+        )?;
+        Ok(Self {
+            conn: std::sync::Mutex::new(conn),
+        })
+    }
+
+    fn insert_batch(&self, records: &[FlowRecord]) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        for record in records {
+            tx.execute(
+                "INSERT INTO flow_records (request_id, timestamp, method, path, model, stream, input_tokens, output_tokens, duration_ms, status_code, error, user_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                rusqlite::params![
+                    record.request_id,
+                    record.timestamp,
+                    record.method,
+                    record.path,
+                    record.model,
+                    record.stream as i32,
+                    record.input_tokens,
+                    record.output_tokens,
+                    record.duration_ms,
+                    record.status_code as i32,
+                    record.error,
+                    record.user_id,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn query(&self, filter: &FlowQuery) -> Result<FlowListResponse> {
+        let conn = self.conn.lock().unwrap();
+        let page = filter.page.unwrap_or(1).max(1);
+        let page_size = filter.page_size.unwrap_or(50).clamp(1, 200);
+        let offset = (page - 1) * page_size;
+
+        let mut where_clauses = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(ref model) = filter.model {
+            where_clauses.push(format!("model = ?{}", params.len() + 1));
+            params.push(Box::new(model.clone()));
+        }
+        if let Some(ref status) = filter.status {
+            match status.as_str() {
+                "success" => {
+                    where_clauses.push(format!("status_code < ?{}", params.len() + 1));
+                    params.push(Box::new(400i32));
+                }
+                "error" => {
+                    where_clauses.push(format!("status_code >= ?{}", params.len() + 1));
+                    params.push(Box::new(400i32));
+                }
+                _ => {}
+            }
+        }
+        if let Some(ref start_time) = filter.start_time {
+            let normalized = chrono::DateTime::parse_from_rfc3339(start_time)
+                .map(|dt| dt.with_timezone(&Utc).to_rfc3339())
+                .unwrap_or_else(|_| start_time.clone());
+            where_clauses.push(format!("timestamp >= ?{}", params.len() + 1));
+            params.push(Box::new(normalized));
+        }
+        if let Some(ref end_time) = filter.end_time {
+            let normalized = chrono::DateTime::parse_from_rfc3339(end_time)
+                .map(|dt| dt.with_timezone(&Utc).to_rfc3339())
+                .unwrap_or_else(|_| end_time.clone());
+            where_clauses.push(format!("timestamp <= ?{}", params.len() + 1));
+            params.push(Box::new(normalized));
+        }
+
+        let where_sql = if where_clauses.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", where_clauses.join(" AND "))
+        };
+
+        // Count total
+        let count_sql = format!("SELECT COUNT(*) FROM flow_records {}", where_sql);
+        let total: u64 = conn.query_row(
+            &count_sql,
+            rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+            |row| row.get(0),
+        )?;
+
+        // Query records
+        let query_sql = format!(
+            "SELECT id, request_id, timestamp, method, path, model, stream, input_tokens, output_tokens, duration_ms, status_code, error, user_id
+             FROM flow_records {} ORDER BY id DESC LIMIT ?{} OFFSET ?{}",
+            where_sql,
+            params.len() + 1,
+            params.len() + 2
+        );
+        params.push(Box::new(page_size as i64));
+        params.push(Box::new(offset as i64));
+
+        let mut stmt = conn.prepare(&query_sql)?;
+        let records = stmt
+            .query_map(
+                rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+                |row| {
+                    let input_tokens: Option<i64> = row.get(7)?;
+                    let output_tokens: Option<i64> = row.get(8)?;
+                    let total_tokens = match (input_tokens, output_tokens) {
+                        (Some(i), Some(o)) => Some(i + o),
+                        _ => None,
+                    };
+                    Ok(FlowRecordResponse {
+                        id: row.get(0)?,
+                        request_id: row.get(1)?,
+                        timestamp: row.get(2)?,
+                        path: row.get(4)?,
+                        model: row.get(5)?,
+                        stream: row.get::<_, i32>(6)? != 0,
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                        duration_ms: row.get(9)?,
+                        status_code: row.get::<_, i32>(10)? as u16,
+                        error: row.get(11)?,
+                        user_id: row.get(12)?,
+                    })
+                },
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(FlowListResponse {
+            total,
+            page,
+            page_size,
+            records,
+        })
+    }
+
+    fn get_stats(&self) -> Result<FlowStatsResponse> {
+        let conn = self.conn.lock().unwrap();
+
+        let (total_requests, total_input, total_output, avg_duration, error_count): (u64, i64, i64, f64, u64) = conn.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(AVG(duration_ms), 0), COUNT(CASE WHEN status_code >= 400 THEN 1 END) FROM flow_records",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )?;
+
+        let error_rate = if total_requests > 0 {
+            error_count as f64 / total_requests as f64
+        } else {
+            0.0
+        };
+
+        let mut stmt = conn.prepare(
+            "SELECT model, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(AVG(duration_ms), 0) FROM flow_records GROUP BY model ORDER BY COUNT(*) DESC"
+        )?;
+        let models = stmt
+            .query_map([], |row| {
+                Ok(ModelStats {
+                    model: row.get(0)?,
+                    count: row.get(1)?,
+                    total_input_tokens: row.get(2)?,
+                    total_output_tokens: row.get(3)?,
+                    avg_duration_ms: row.get(4)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(FlowStatsResponse {
+            total_requests,
+            total_input_tokens: total_input,
+            total_output_tokens: total_output,
+            total_tokens: total_input + total_output,
+            avg_duration_ms: avg_duration,
+            error_count,
+            error_rate,
+            models,
+        })
+    }
+
+    fn clear(&self, before: Option<&str>) -> Result<u64> {
+        let conn = self.conn.lock().unwrap();
+        let count = if let Some(before) = before {
+            let normalized = chrono::DateTime::parse_from_rfc3339(before)
+                .map(|dt| dt.with_timezone(&Utc).to_rfc3339())
+                .unwrap_or_else(|_| before.to_string());
+            conn.execute("DELETE FROM flow_records WHERE timestamp < ?1", [&normalized])?
+        } else {
+            conn.execute("DELETE FROM flow_records", [])?
+        };
+        Ok(count as u64)
+    }
+}
+
+/// 异步流量监控服务（公开 API）
+pub struct FlowMonitor {
+    sender: mpsc::Sender<FlowRecord>,
+    store: Arc<FlowStore>,
+}
+
+impl FlowMonitor {
+    /// 创建新的 FlowMonitor，启动后台写入任务
+    pub fn new(db_path: &str) -> Result<Self> {
+        let store = Arc::new(FlowStore::new(db_path)?);
+        let (sender, mut receiver) = mpsc::channel::<FlowRecord>(10_000);
+
+        let write_store = store.clone();
+        tokio::spawn(async move {
+            while let Some(first) = receiver.recv().await {
+                // Drain all available records into a batch
+                let mut batch = vec![first];
+                while let Ok(record) = receiver.try_recv() {
+                    batch.push(record);
+                    if batch.len() >= 500 {
+                        break;
+                    }
+                }
+                let store = write_store.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Err(e) = store.insert_batch(&batch) {
+                        tracing::error!("批量写入流量记录失败: {}", e);
+                    }
+                }).await;
+            }
+        });
+
+        Ok(Self { sender, store })
+    }
+
+    /// 非阻塞记录流量（发送到 channel）
+    pub fn record(&self, record: FlowRecord) {
+        if self.sender.try_send(record).is_err() {
+            tracing::warn!("流量记录通道已满，丢弃记录");
+        }
+    }
+
+    /// 查询流量记录
+    pub async fn query(&self, filter: FlowQuery) -> Result<FlowListResponse> {
+        let store = self.store.clone();
+        tokio::task::spawn_blocking(move || store.query(&filter)).await?
+    }
+
+    /// 获取统计信息
+    pub async fn get_stats(&self) -> Result<FlowStatsResponse> {
+        let store = self.store.clone();
+        tokio::task::spawn_blocking(move || store.get_stats()).await?
+    }
+
+    /// 清空记录
+    pub async fn clear(&self, before: Option<String>) -> Result<u64> {
+        let store = self.store.clone();
+        tokio::task::spawn_blocking(move || store.clear(before.as_deref())).await?
+    }
+}

--- a/src/flow_monitor/types.rs
+++ b/src/flow_monitor/types.rs
@@ -1,0 +1,68 @@
+//! Flow Monitor API 请求/响应类型
+
+use serde::{Deserialize, Serialize};
+
+/// 查询过滤器
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlowQuery {
+    pub page: Option<u32>,
+    pub page_size: Option<u32>,
+    pub model: Option<String>,
+    pub status: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+}
+
+/// 分页响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlowListResponse {
+    pub total: u64,
+    pub page: u32,
+    pub page_size: u32,
+    pub records: Vec<FlowRecordResponse>,
+}
+
+/// 单条记录响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlowRecordResponse {
+    pub id: i64,
+    pub request_id: String,
+    pub timestamp: String,
+    pub path: String,
+    pub model: String,
+    pub stream: bool,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub total_tokens: Option<i64>,
+    pub duration_ms: i64,
+    pub status_code: u16,
+    pub error: Option<String>,
+    pub user_id: Option<String>,
+}
+
+/// 统计响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlowStatsResponse {
+    pub total_requests: u64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub total_tokens: i64,
+    pub avg_duration_ms: f64,
+    pub error_count: u64,
+    pub error_rate: f64,
+    pub models: Vec<ModelStats>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelStats {
+    pub model: String,
+    pub count: u64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub avg_duration_ms: f64,
+}


### PR DESCRIPTION
   (flow-monitor)
   新增 SQLite 流量记录存储，支持按模型/状态/时间过滤查询、                               统计面板和分页浏览。前端使用 React Query 轮询 + shadcn/ui                              组件实现实时监控仪表盘。                                                                                                                                                      后端:                                                                                  - flow_monitor 模块: store (批量写入+spawn_blocking)、                                   handlers (RFC3339 校验)、router (认证中间件)、types
   - anthropic middleware: 记录请求流量并提取上游真实状态码
   - DELETE /flows 使用 query param 而非 request body

   前端:
   - flow-monitor.tsx: 统计卡片、模型筛选、状态筛选、分页表格、 Dialog 确认清空（替代 native confirm）
   - flows.ts: API 层 (axios)
   - use-flows.ts: React Query hooks (轮询+缓存失效)
   - dashboard.tsx: 流量监控 tab 集成