### PR TITLE
fix: 修复连续 assistant 消息导致 400 错误的问题

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -571,24 +571,35 @@ fn build_history(req: &MessagesRequest, model_id: &str) -> Result<Vec<Message>, 
 
     // 收集并配对消息
     let mut user_buffer: Vec<&super::types::Message> = Vec::new();
+    let mut assistant_buffer: Vec<&super::types::Message> = Vec::new();
 
     for i in 0..history_end_index {
         let msg = &req.messages[i];
 
         if msg.role == "user" {
+            // 先处理累积的 assistant 消息
+            if !assistant_buffer.is_empty() {
+                let merged = merge_assistant_messages(&assistant_buffer)?;
+                history.push(Message::Assistant(merged));
+                assistant_buffer.clear();
+            }
             user_buffer.push(msg);
         } else if msg.role == "assistant" {
-            // 遇到 assistant，处理累积的 user 消息
+            // 先处理累积的 user 消息
             if !user_buffer.is_empty() {
                 let merged_user = merge_user_messages(&user_buffer, model_id)?;
                 history.push(Message::User(merged_user));
                 user_buffer.clear();
-
-                // 添加 assistant 消息
-                let assistant = convert_assistant_message(msg)?;
-                history.push(Message::Assistant(assistant));
             }
+            // 累积 assistant 消息（支持连续多条）
+            assistant_buffer.push(msg);
         }
+    }
+
+    // 处理末尾累积的 assistant 消息
+    if !assistant_buffer.is_empty() {
+        let merged = merge_assistant_messages(&assistant_buffer)?;
+        history.push(Message::Assistant(merged));
     }
 
     // 处理结尾的孤立 user 消息
@@ -704,6 +715,45 @@ fn convert_assistant_message(
         assistant = assistant.with_tool_uses(tool_uses);
     }
 
+    Ok(HistoryAssistantMessage {
+        assistant_response_message: assistant,
+    })
+}
+
+/// 合并多个连续的 assistant 消息为一条
+/// 用于处理网络不稳定时产生的连续 assistant 消息（Issue #79）
+fn merge_assistant_messages(
+    messages: &[&super::types::Message],
+) -> Result<HistoryAssistantMessage, ConversionError> {
+    assert!(!messages.is_empty());
+    if messages.len() == 1 {
+        return convert_assistant_message(messages[0]);
+    }
+
+    let mut all_tool_uses: Vec<ToolUseEntry> = Vec::new();
+    let mut content_parts: Vec<String> = Vec::new();
+
+    for msg in messages {
+        let converted = convert_assistant_message(msg)?;
+        let am = converted.assistant_response_message;
+        if !am.content.trim().is_empty() {
+            content_parts.push(am.content);
+        }
+        if let Some(tus) = am.tool_uses {
+            all_tool_uses.extend(tus);
+        }
+    }
+
+    let content = if content_parts.is_empty() && !all_tool_uses.is_empty() {
+        " ".to_string()
+    } else {
+        content_parts.join("\n\n")
+    };
+
+    let mut assistant = AssistantMessage::new(content);
+    if !all_tool_uses.is_empty() {
+        assistant = assistant.with_tool_uses(all_tool_uses);
+    }
     Ok(HistoryAssistantMessage {
         assistant_response_message: assistant,
     })
@@ -1320,5 +1370,101 @@ mod tests {
         } else {
             panic!("应该是 Assistant 消息");
         }
+    }
+
+    #[test]
+    fn test_merge_consecutive_assistant_messages() {
+        // 测试连续 assistant 消息被正确合并（Issue #79）
+        use super::super::types::Message as AnthropicMessage;
+
+        let msg1 = AnthropicMessage {
+            role: "assistant".to_string(),
+            content: serde_json::json!([
+                {"type": "thinking", "thinking": "Let me think about this..."},
+                {"type": "text", "text": " "}
+            ]),
+        };
+
+        let msg2 = AnthropicMessage {
+            role: "assistant".to_string(),
+            content: serde_json::json!([
+                {"type": "thinking", "thinking": "I should read the file."},
+                {"type": "text", "text": "Let me read that file."},
+                {"type": "tool_use", "id": "toolu_01ABC", "name": "read_file", "input": {"path": "/test.txt"}}
+            ]),
+        };
+
+        let messages: Vec<&AnthropicMessage> = vec![&msg1, &msg2];
+        let result = merge_assistant_messages(&messages).expect("合并应成功");
+
+        let content = &result.assistant_response_message.content;
+        assert!(content.contains("<thinking>"), "应包含 thinking 标签");
+        assert!(content.contains("Let me read that file"), "应包含第二条消息的 text 内容");
+
+        let tool_uses = result.assistant_response_message.tool_uses.expect("应有 tool_uses");
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].tool_use_id, "toolu_01ABC");
+    }
+
+    #[test]
+    fn test_consecutive_assistant_with_tool_use_result_pairing() {
+        // 测试 Issue #79 的完整场景
+        use super::super::types::Message as AnthropicMessage;
+
+        let req = MessagesRequest {
+            model: "claude-sonnet-4".to_string(),
+            max_tokens: 1024,
+            messages: vec![
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!("Read the config file"),
+                },
+                AnthropicMessage {
+                    role: "assistant".to_string(),
+                    content: serde_json::json!([
+                        {"type": "thinking", "thinking": "I need to read the file..."},
+                        {"type": "text", "text": " "}
+                    ]),
+                },
+                AnthropicMessage {
+                    role: "assistant".to_string(),
+                    content: serde_json::json!([
+                        {"type": "thinking", "thinking": "Let me read the config."},
+                        {"type": "text", "text": "I'll read the config file for you."},
+                        {"type": "tool_use", "id": "toolu_01XYZ", "name": "read_file", "input": {"path": "/config.json"}}
+                    ]),
+                },
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!([
+                        {"type": "tool_result", "tool_use_id": "toolu_01XYZ", "content": "{\"key\": \"value\"}"}
+                    ]),
+                },
+            ],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: None,
+        };
+
+        let result = convert_request(&req);
+        assert!(result.is_ok(), "连续 assistant 消息场景不应报错: {:?}", result.err());
+
+        let state = result.unwrap().conversation_state;
+        let mut found_tool_use = false;
+        for msg in &state.history {
+            if let Message::Assistant(assistant_msg) = msg {
+                if let Some(ref tool_uses) = assistant_msg.assistant_response_message.tool_uses {
+                    if tool_uses.iter().any(|t| t.tool_use_id == "toolu_01XYZ") {
+                        found_tool_use = true;
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(found_tool_use, "合并后的 assistant 消息应包含 tool_use");
     }
 }


### PR DESCRIPTION
## 问题描述

修复 Issue #79：Claude Code 在网络不稳定时可能产生连续两条 assistant 消息，导致 Kiro API 返回 400 错误。

### 根本原因

`build_history` 函数只在 `user_buffer` 非空时处理 assistant 消息。连续的第二条 assistant 消息被跳过，导致其中的 `tool_use` 丢失，后续 `tool_result` 找不到配对。

### 修复方案

- 添加 `merge_assistant_messages` 函数合并连续 assistant 消息
- 修改 `build_history` 使用 `assistant_buffer` 累积连续消息
- 添加单元测试覆盖合并和配对场景

### 测试验证

```bash
cargo test test_merge_consecutive_assistant
cargo test test_consecutive_assistant_with_tool_use
```

Closes #79