### PR TITLE
feat: 为凭证添加 disabled 字段持久化支持

### DIFF
--- a/credentials.example.multiple.json
+++ b/credentials.example.multiple.json
@@ -14,6 +14,7 @@
     "clientSecret": "xxxxxxxxx",
     "region": "us-east-2",
     "machineId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "priority": 1
+    "priority": 1,
+    "disabled": true
   }
 ]

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -207,6 +207,7 @@ impl AdminService {
             proxy_url: req.proxy_url,
             proxy_username: req.proxy_username,
             proxy_password: req.proxy_password,
+            disabled: false, // 新添加的凭据默认启用
         };
 
         // 调用 token_manager 添加凭据

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -92,6 +92,10 @@ pub struct KiroCredentials {
     /// 凭据级代理认证密码（可选）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy_password: Option<String>,
+
+    /// 凭据是否被禁用（默认为 false）
+    #[serde(default)]
+    pub disabled: bool,
 }
 
 /// 判断是否为零（用于跳过序列化）
@@ -334,6 +338,7 @@ mod tests {
             proxy_url: None,
             proxy_username: None,
             proxy_password: None,
+            disabled: false,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -451,6 +456,7 @@ mod tests {
             proxy_url: None,
             proxy_username: None,
             proxy_password: None,
+            disabled: false,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -480,6 +486,7 @@ mod tests {
             proxy_url: None,
             proxy_username: None,
             proxy_password: None,
+            disabled: false,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -591,6 +598,7 @@ mod tests {
             proxy_url: None,
             proxy_username: None,
             proxy_password: None,
+            disabled: false,
         };
 
         let json = original.to_pretty_json().unwrap();

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -563,10 +563,14 @@ impl MultiTokenManager {
                 }
                 CredentialEntry {
                     id,
-                    credentials: cred,
+                    credentials: cred.clone(),
                     failure_count: 0,
-                    disabled: false,
-                    disabled_reason: None,
+                    disabled: cred.disabled, // 从配置文件读取 disabled 状态
+                    disabled_reason: if cred.disabled {
+                        Some(DisabledReason::Manual)
+                    } else {
+                        None
+                    },
                     success_count: 0,
                     last_used_at: None,
                 }
@@ -951,6 +955,8 @@ impl MultiTokenManager {
                 .map(|e| {
                     let mut cred = e.credentials.clone();
                     cred.canonicalize_auth_method();
+                    // 同步 disabled 状态到凭据对象
+                    cred.disabled = e.disabled;
                     cred
                 })
                 .collect()


### PR DESCRIPTION
## 功能说明

为凭证添加 `disabled` 字段的持久化支持，使得通过 Admin API 禁用/启用凭证的操作能够保存到配置文件中，重启应用后状态得以保留。

## 实现内容

1. **在 `KiroCredentials` 模型中添加 `disabled` 字段**
   - 默认值为 `false`（启用状态）
   - 使用 `#[serde(default)]` 确保向后兼容

2. **更新 `CredentialEntry` 初始化逻辑**
   - 从配置文件读取 `disabled` 状态
   - 如果 `disabled=true`，初始化时设置为手动禁用状态

3. **更新凭证持久化逻辑**
   - 在保存凭证到文件时，同步当前的 `disabled` 状态
   - 确保前端 UI 的禁用操作能持久化到配置文件

4. **更新示例配置文件**
   - 添加了 `disabled: true` 的示例

## 测试结果

✅ 所有功能正常

- 禁用凭据：通过 Admin API 禁用凭据，`disabled` 字段成功写入 `credentials.json`
- 持久化验证：重启应用后，凭据的禁用状态被正确读取并保持
- 重新启用：通过 Admin API 重新启用凭据，`disabled` 字段更新为 `false`
- 向后兼容：没有 `disabled` 字段的旧凭据默认为 `false`（启用状态）

## 使用方式

在 `credentials.json` 文件中，可以为每个凭证添加 `disabled` 字段：

```json
[
  {
    "refreshToken": "xxx",
    "priority": 0
  },
  {
    "refreshToken": "yyy",
    "priority": 1,
    "disabled": true
  }
]
```

- 当用户在前端 UI 禁用/启用凭证时，状态会自动保存到配置文件
- 重启应用后，禁用状态会被保留
- 如果配置文件中没有 `disabled` 字段，默认为 `false`（启用状态）