### PR TITLE
fix(token): handle missing access_token and simplify refresh headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /credentials.*
 /kiro_balance_cache.json
 /kiro_stats.json
+/.claude/


### PR DESCRIPTION
## 改动说明

### fix:  处理  为空的情况

之前当  为  时，会直接进入过期时间判断逻辑，可能导致意外行为。现在提前判断，若  不存在则直接视为已过期，触发刷新流程。

### fix: 修正 Social Token 刷新的 User-Agent 格式

将 User-Agent 格式从 `KiroIDE-{version}-{machineId}` 修正为与官方客户端一致的格式：
`aws-sdk-js/1.0.18 ua/2.1 os/windows lang/js md/nodejs#20.16.0 api/codewhispererstreaming#1.0.18 m/E KiroIDE-{version}-{machineId}`

同时移除了多余的请求头（`Accept-Encoding`、`host`、`Connection` 等）。

### fix: 简化 IdC Token 刷新的请求头

移除了 IdC 刷新请求中冗余的请求头（`Host`、`Connection`、`x-amz-user-agent`、`Accept` 等），保留必要的 `Content-Type`。

### chore: 增加 IdC Token 刷新的 tracing 日志

在 IdC 刷新流程的关键节点添加了日志输出，便于排查认证问题。