### PR TITLE
feat: add POST /api/admin/credentials/:id/refresh endpoint

### DIFF
--- a/admin-ui/src/lucide-react.d.ts
+++ b/admin-ui/src/lucide-react.d.ts
@@ -1,0 +1,1 @@
+declare module "lucide-react";

--- a/config.local.json
+++ b/config.local.json
@@ -1,0 +1,8 @@
+{
+  "host": "127.0.0.1",
+  "port": 18990,
+  "apiKey": "sk-kiro-rs-local-test",
+  "region": "us-east-1",
+  "adminApiKey": "admin-local-test",
+  "enableAdmin": true
+}

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -70,6 +70,23 @@ pub async fn reset_failure_count(
     }
 }
 
+/// POST /api/admin/credentials/:id/refresh
+/// 强制刷新指定凭据的 Token
+pub async fn force_refresh_token(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+) -> impl IntoResponse {
+    match state.service.force_refresh_token(id).await {
+        Ok(got_new_refresh) => Json(serde_json::json!({
+            "success": true,
+            "message": format!("凭据 #{} Token 已刷新", id),
+            "newRefreshToken": got_new_refresh
+        }))
+        .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
 /// GET /api/admin/credentials/:id/balance
 /// 获取指定凭据的余额
 pub async fn get_credential_balance(

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -7,9 +7,9 @@ use axum::{
 
 use super::{
     handlers::{
-        add_credential, delete_credential, get_all_credentials, get_credential_balance,
-        get_load_balancing_mode, reset_failure_count, set_credential_disabled,
-        set_credential_priority, set_load_balancing_mode,
+        add_credential, delete_credential, force_refresh_token, get_all_credentials,
+        get_credential_balance, get_load_balancing_mode, reset_failure_count,
+        set_credential_disabled, set_credential_priority, set_load_balancing_mode,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -41,6 +41,7 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))
         .route("/credentials/{id}/reset", post(reset_failure_count))
+        .route("/credentials/{id}/refresh", post(force_refresh_token))
         .route("/credentials/{id}/balance", get(get_credential_balance))
         .route(
             "/config/load-balancing",

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -231,6 +231,13 @@ impl AdminService {
     }
 
     /// 删除凭据
+    pub async fn force_refresh_token(&self, id: u64) -> Result<bool, AdminServiceError> {
+        self.token_manager
+            .force_refresh_token(id)
+            .await
+            .map_err(|e| self.classify_error(e, id))
+    }
+
     pub fn delete_credential(&self, id: u64) -> Result<(), AdminServiceError> {
         self.token_manager
             .delete_credential(id)


### PR DESCRIPTION
## What

Add a new admin endpoint `POST /api/admin/credentials/:id/refresh` that forces an immediate token refresh for a specific credential, regardless of whether the current token is expiring.

## Why

Social auth credentials (Google/GitHub/Apple) have refresh tokens that expire after ~6 hours of inactivity. The existing auto-refresh only triggers when the access token is about to expire, which means if there's no traffic for a few hours, the refresh token chain breaks and the credential becomes permanently invalid — requiring manual deletion and re-addition.

This endpoint enables external orchestration tools (e.g., a feeder/scheduler) to periodically call refresh on idle credentials, keeping the token chain alive.

## Changes

- `src/kiro/token_manager.rs`: Added `force_refresh_token(id)` method on `MultiTokenManager`
- `src/admin/service.rs`: Added `force_refresh_token(id)` service method
- `src/admin/handlers.rs`: Added `force_refresh_token` handler
- `src/admin/router.rs`: Registered `POST /credentials/{id}/refresh` route

## Response

```json
{
  "success": true,
  "message": "凭据 #1 Token 已刷新",
  "newRefreshToken": true
}
```

The `newRefreshToken` field indicates whether the server returned a new refresh token (useful for monitoring token rotation).