### PR TITLE
Update User-Agent headers and Kiro version

### DIFF
--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -13,7 +13,7 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 use crate::http_client::{ProxyConfig, build_client};
-use crate::kiro::machine_id;
+
 use crate::kiro::model::credentials::KiroCredentials;
 use crate::kiro::token_manager::{CallContext, MultiTokenManager};
 use crate::model::config::TlsBackend;
@@ -149,18 +149,17 @@ impl KiroProvider {
     fn build_headers(&self, ctx: &CallContext) -> anyhow::Result<HeaderMap> {
         let config = self.token_manager.config();
 
-        let machine_id = machine_id::generate_from_credentials(&ctx.credentials, config)
-            .ok_or_else(|| anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"))?;
-
         let kiro_version = &config.kiro_version;
         let os_name = &config.system_version;
-        let node_version = &config.node_version;
 
-        let x_amz_user_agent = format!("aws-sdk-js/1.0.27 KiroIDE-{}-{}", kiro_version, machine_id);
+        let x_amz_user_agent = format!(
+            "aws-sdk-rust/1.92.0 ua/2.1 os/{} lang/rust#1.92.0 api/codewhispererstreaming#1.50.0 m/E app/Kiro-CLI#{}",
+            os_name, kiro_version
+        );
 
         let user_agent = format!(
-            "aws-sdk-js/1.0.27 ua/2.1 os/{} lang/js md/nodejs#{} api/codewhispererstreaming#1.0.27 m/E KiroIDE-{}-{}",
-            os_name, node_version, kiro_version, machine_id
+            "aws-sdk-rust/1.92.0 ua/2.1 os/{} lang/rust#1.92.0 md/http#reqwest api/codewhispererstreaming#1.50.0 m/E app/Kiro-CLI#{}",
+            os_name, kiro_version
         );
 
         let mut headers = HeaderMap::new();
@@ -201,18 +200,17 @@ impl KiroProvider {
     fn build_mcp_headers(&self, ctx: &CallContext) -> anyhow::Result<HeaderMap> {
         let config = self.token_manager.config();
 
-        let machine_id = machine_id::generate_from_credentials(&ctx.credentials, config)
-            .ok_or_else(|| anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"))?;
-
         let kiro_version = &config.kiro_version;
         let os_name = &config.system_version;
-        let node_version = &config.node_version;
 
-        let x_amz_user_agent = format!("aws-sdk-js/1.0.27 KiroIDE-{}-{}", kiro_version, machine_id);
+        let x_amz_user_agent = format!(
+            "aws-sdk-rust/1.92.0 ua/2.1 os/{} lang/rust#1.92.0 api/codewhispererstreaming#1.50.0 m/E app/Kiro-CLI#{}",
+            os_name, kiro_version
+        );
 
         let user_agent = format!(
-            "aws-sdk-js/1.0.27 ua/2.1 os/{} lang/js md/nodejs#{} api/codewhispererstreaming#1.0.27 m/E KiroIDE-{}-{}",
-            os_name, node_version, kiro_version, machine_id
+            "aws-sdk-rust/1.92.0 ua/2.1 os/{} lang/rust#1.92.0 md/http#reqwest api/codewhispererstreaming#1.50.0 m/E app/Kiro-CLI#{}",
+            os_name, kiro_version
         );
 
         let mut headers = HeaderMap::new();

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -176,8 +176,6 @@ async fn refresh_social_token(
 
     let refresh_url = format!("https://prod.{}.auth.desktop.kiro.dev/refreshToken", region);
     let refresh_domain = format!("prod.{}.auth.desktop.kiro.dev", region);
-    let machine_id = machine_id::generate_from_credentials(credentials, config)
-        .ok_or_else(|| anyhow::anyhow!("无法生成 machineId"))?;
     let kiro_version = &config.kiro_version;
 
     let client = build_client(proxy, 60, config.tls_backend)?;
@@ -191,7 +189,7 @@ async fn refresh_social_token(
         .header("Content-Type", "application/json")
         .header(
             "User-Agent",
-            format!("KiroIDE-{}-{}", kiro_version, machine_id),
+            format!("Kiro-CLI/{}", kiro_version),
         )
         .header("Accept-Encoding", "gzip, compress, deflate, br")
         .header("host", &refresh_domain)
@@ -235,7 +233,7 @@ async fn refresh_social_token(
 }
 
 /// IdC Token 刷新所需的 x-amz-user-agent header
-const IDC_AMZ_USER_AGENT: &str = "aws-sdk-js/3.738.0 ua/2.1 os/other lang/js md/browser#unknown_unknown api/sso-oidc#3.738.0 m/E KiroIDE";
+const IDC_AMZ_USER_AGENT: &str = "aws-sdk-rust/1.92.0 ua/2.1 os/other lang/rust#1.92.0 api/sso-oidc#1.50.0 m/E app/Kiro-CLI";
 
 /// 刷新 IdC Token (AWS SSO OIDC)
 async fn refresh_idc_token(
@@ -313,7 +311,7 @@ async fn refresh_idc_token(
 }
 
 /// getUsageLimits API 所需的 x-amz-user-agent header 前缀
-const USAGE_LIMITS_AMZ_USER_AGENT_PREFIX: &str = "aws-sdk-js/1.0.0";
+const USAGE_LIMITS_AMZ_USER_AGENT_PREFIX: &str = "aws-sdk-rust/1.92.0";
 
 /// 获取使用额度信息
 pub(crate) async fn get_usage_limits(
@@ -327,8 +325,6 @@ pub(crate) async fn get_usage_limits(
     // 优先级：凭据.api_region > config.api_region > config.region
     let region = credentials.effective_api_region(config);
     let host = format!("q.{}.amazonaws.com", region);
-    let machine_id = machine_id::generate_from_credentials(credentials, config)
-        .ok_or_else(|| anyhow::anyhow!("无法生成 machineId"))?;
     let kiro_version = &config.kiro_version;
 
     // 构建 URL
@@ -344,13 +340,13 @@ pub(crate) async fn get_usage_limits(
 
     // 构建 User-Agent headers
     let user_agent = format!(
-        "aws-sdk-js/1.0.0 ua/2.1 os/darwin#24.6.0 lang/js md/nodejs#22.21.1 \
-         api/codewhispererruntime#1.0.0 m/N,E KiroIDE-{}-{}",
-        kiro_version, machine_id
+        "aws-sdk-rust/1.92.0 ua/2.1 os/macos#24.6.0 lang/rust#1.92.0 \
+         api/codewhispererruntime#1.50.0 m/N,E app/Kiro-CLI#{}",
+        kiro_version
     );
     let amz_user_agent = format!(
-        "{} KiroIDE-{}-{}",
-        USAGE_LIMITS_AMZ_USER_AGENT_PREFIX, kiro_version, machine_id
+        "{} app/Kiro-CLI#{}",
+        USAGE_LIMITS_AMZ_USER_AGENT_PREFIX, kiro_version
     );
 
     let client = build_client(proxy, 60, config.tls_backend)?;

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -108,7 +108,7 @@ fn default_region() -> String {
 }
 
 fn default_kiro_version() -> String {
-    "0.10.0".to_string()
+    "1.27.1".to_string()
 }
 
 fn default_system_version() -> String {


### PR DESCRIPTION
- Replace machine_id-based User-Agent with Rust SDK format
- Update User-Agent strings to use aws-sdk-rust/1.92.0
- Update Kiro version from 0.10.0 to 1.27.1
- Remove unused machine_id generation calls
- Update API headers for consistency with Rust implementation