### PR TITLE
fix: unify get_context_window_size with map_model to fix incorrect context window for opus-4 models

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -102,6 +102,17 @@ pub fn map_model(model: &str) -> Option<String> {
     }
 }
 
+/// 根据模型名称返回对应的上下文窗口大小
+///
+/// 复用 `map_model` 的映射逻辑，确保窗口大小判断与模型映射一致。
+/// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
+pub fn get_context_window_size(model: &str) -> i32 {
+    match map_model(model) {
+        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" => 1_000_000,
+        _ => 200_000,
+    }
+}
+
 /// 转换结果
 #[derive(Debug)]
 pub struct ConversionResult {

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -428,19 +428,7 @@ fn create_sse_stream(
     initial_stream.chain(processing_stream)
 }
 
-/// 根据模型名称返回对应的上下文窗口大小
-/// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文
-fn get_context_window_size(model: &str) -> i32 {
-    let m = model.to_lowercase();
-    if m.contains("opus-4-6") || m.contains("opus-4.6")
-        || m.contains("sonnet-4-6") || m.contains("sonnet-4.6")
-        || m.contains("claude-opus-4-6") || m.contains("claude-sonnet-4-6")
-    {
-        1_000_000
-    } else {
-        200_000
-    }
-}
+use super::converter::get_context_window_size;
 
 /// 处理非流式请求
 async fn handle_non_stream_request(

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -453,19 +453,7 @@ impl SseStateManager {
     }
 }
 
-/// 根据模型名称返回对应的上下文窗口大小
-/// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文
-fn get_context_window_size(model: &str) -> i32 {
-    let m = model.to_lowercase();
-    if m.contains("opus-4-6") || m.contains("opus-4.6")
-        || m.contains("sonnet-4-6") || m.contains("sonnet-4.6")
-        || m.contains("claude-opus-4-6") || m.contains("claude-sonnet-4-6")
-    {
-        1_000_000
-    } else {
-        200_000
-    }
-}
+use super::converter::get_context_window_size;
 
 /// 流处理上下文
 pub struct StreamContext {


### PR DESCRIPTION
## Problem

`get_context_window_size` in `handlers.rs` and `stream.rs` used string matching (`contains("opus-4-6")`, etc.) to determine the context window size. This logic was inconsistent with `map_model` in `converter.rs`.

For example, when a user sends model name `claude-opus-4-20250514` (without explicit `4-6` or `4-5`), `map_model` correctly maps it to `claude-opus-4.6` (1M context), but `get_context_window_size` would fall through to the default 200k — causing `input_tokens` calculated from `contextUsageEvent` to be 5x lower than actual.

## Fix

- Extract `get_context_window_size` into `converter.rs`, reusing `map_model` result to determine window size
- Remove duplicate definitions from `handlers.rs` and `stream.rs`
- This ensures context window size judgment is always consistent with model mapping