### PR TITLE
fix: IdC Token 刷新时同步更新 profile_arn

### DIFF
--- a/src/kiro/model/token_refresh.rs
+++ b/src/kiro/model/token_refresh.rs
@@ -41,4 +41,6 @@ pub struct IdcRefreshResponse {
     // pub token_type: Option<String>,
     #[serde(default)]
     pub expires_in: Option<i64>,
+    #[serde(default)]
+    pub profile_arn: Option<String>,
 }

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -312,6 +312,11 @@ async fn refresh_idc_token(
         new_credentials.expires_at = Some(expires_at.to_rfc3339());
     }
 
+    // 同步更新 profile_arn（如果 IdC 响应中包含）
+    if let Some(profile_arn) = data.profile_arn {
+        new_credentials.profile_arn = Some(profile_arn);
+    }
+
     Ok(new_credentials)
 }
 


### PR DESCRIPTION
- 为 IdcRefreshResponse 添加 profile_arn 字段
- 在 refresh_idc_token 函数中添加 profile_arn 更新逻辑
- 确保 idc/builder-id/iam 认证方式与 Social 认证保持一致

修复了 idc/buildid/iam 三种认证方式在 Token 刷新时未更新 profile_arn 的问题