### PR TITLE
fix: 为 IdC/Builder-ID/IAM/Social 对话请求添加 profile_arn header

### DIFF
--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -375,13 +375,20 @@ impl KiroProvider {
             );
 
             // 发送请求
-            let response = match self
+            let mut request = self
                 .client_for(&ctx.credentials)?
                 .post(&url)
                 .body(request_body.to_string())
                 .header("content-type", "application/json")
                 .header("x-amzn-codewhisperer-optout", "true")
-                .header("x-amzn-kiro-agent-mode", "vibe")
+                .header("x-amzn-kiro-agent-mode", "vibe");
+
+            // 对话请求需要携带 profile ARN（如果凭据中存在）
+            if let Some(ref arn) = ctx.credentials.profile_arn {
+                request = request.header("x-amzn-kiro-profile-arn", arn);
+            }
+
+            let response = match request
                 .header("x-amz-user-agent", &x_amz_user_agent)
                 .header("user-agent", &user_agent)
                 .header("host", &self.base_domain_for(&ctx.credentials))


### PR DESCRIPTION
- 在 call_api_with_retry 函数中添加 x-amzn-kiro-profile-arn header
- 当凭据中存在 profile_arn 时，对话请求会携带该 header
- 与 MCP 请求的行为保持一致
- 适用于 IdC/Builder-ID/IAM/Social 所有认证方式

现在所有认证方式的对话请求都会传递 profile_arn 了。