### PR TITLE
feat: 新增 KIRO_API_KEY 支持，接入 Kiro CLI headless 模式认证

### DIFF
--- a/credentials.example.apikey.json
+++ b/credentials.example.apikey.json
@@ -1,0 +1,4 @@
+{
+    "kiroApiKey": "ksk_your_api_key_here",
+    "authMethod": "api_key"
+}

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -210,6 +210,7 @@ impl AdminService {
             proxy_username: req.proxy_username,
             proxy_password: req.proxy_password,
             disabled: false, // 新添加的凭据默认启用
+            kiro_api_key: None,
         };
 
         // 调用 token_manager 添加凭据

--- a/src/kiro/machine_id.rs
+++ b/src/kiro/machine_id.rs
@@ -57,6 +57,13 @@ pub fn generate_from_credentials(credentials: &KiroCredentials, config: &Config)
         }
     }
 
+    // 使用 kiroApiKey 生成（API Key 凭据）
+    if let Some(ref api_key) = credentials.kiro_api_key {
+        if !api_key.is_empty() {
+            return Some(sha256_hex(&format!("KiroAPIKey/{}", api_key)));
+        }
+    }
+
     // 没有有效的凭证
     None
 }

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -96,6 +96,12 @@ pub struct KiroCredentials {
     /// 凭据是否被禁用（默认为 false）
     #[serde(default)]
     pub disabled: bool,
+
+    /// Kiro API Key（headless 模式）
+    /// 格式: ksk_xxxxxxxx
+    /// 设置后直接作为 Bearer Token 使用，无需 refreshToken
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kiro_api_key: Option<String>,
 }
 
 /// 判断是否为零（用于跳过序列化）
@@ -106,6 +112,8 @@ fn is_zero(value: &u32) -> bool {
 fn canonicalize_auth_method_value(value: &str) -> &str {
     if value.eq_ignore_ascii_case("builder-id") || value.eq_ignore_ascii_case("iam") {
         "idc"
+    } else if value.eq_ignore_ascii_case("api_key") || value.eq_ignore_ascii_case("apikey") {
+        "api_key"
     } else {
         value
     }
@@ -245,6 +253,18 @@ impl KiroCredentials {
             None => true,
         }
     }
+
+    /// 检查是否为 API Key 凭据
+    ///
+    /// API Key 凭据直接使用 kiro_api_key 作为 Bearer Token，无需 refreshToken
+    pub fn is_api_key_credential(&self) -> bool {
+        self.kiro_api_key.is_some()
+            || self
+                .auth_method
+                .as_deref()
+                .map(|m| m.eq_ignore_ascii_case("api_key") || m.eq_ignore_ascii_case("apikey"))
+                .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]
@@ -314,6 +334,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            kiro_api_key: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -410,7 +431,6 @@ mod tests {
 
     #[test]
     fn test_region_field_serialization() {
-        // 测试序列化时正确输出 region 字段
         let creds = KiroCredentials {
             id: None,
             access_token: None,
@@ -431,6 +451,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            kiro_api_key: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -440,7 +461,6 @@ mod tests {
 
     #[test]
     fn test_region_field_none_not_serialized() {
-        // 测试 region 为 None 时不序列化
         let creds = KiroCredentials {
             id: None,
             access_token: None,
@@ -461,6 +481,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            kiro_api_key: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -573,6 +594,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            kiro_api_key: None,
         };
 
         let json = original.to_pretty_json().unwrap();

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -216,6 +216,10 @@ impl KiroProvider {
                 request = request.header("x-amzn-kiro-profile-arn", arn);
             }
 
+            if ctx.credentials.is_api_key_credential() {
+                request = request.header("tokentype", "API_KEY");
+            }
+
             let response = match request
                 .header("x-amz-user-agent", &x_amz_user_agent)
                 .header("user-agent", &user_agent)
@@ -373,7 +377,7 @@ impl KiroProvider {
             let body = Self::inject_profile_arn(request_body, &ctx.credentials.profile_arn);
 
             // 发送请求
-            let response = match self
+            let mut request = self
                 .client_for(&ctx.credentials)?
                 .post(&url)
                 .body(body)
@@ -386,7 +390,13 @@ impl KiroProvider {
                 .header("amz-sdk-invocation-id", Uuid::new_v4().to_string())
                 .header("amz-sdk-request", "attempt=1; max=3")
                 .header("Authorization", format!("Bearer {}", ctx.token))
-                .header("Connection", "close")
+                .header("Connection", "close");
+
+            if ctx.credentials.is_api_key_credential() {
+                request = request.header("tokentype", "API_KEY");
+            }
+
+            let response = match request
                 .send()
                 .await
             {

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -100,6 +100,11 @@ pub(crate) async fn refresh_token(
     config: &Config,
     proxy: Option<&ProxyConfig>,
 ) -> anyhow::Result<KiroCredentials> {
+    // API Key 凭据不需要刷新，直接返回
+    if credentials.is_api_key_credential() {
+        return Ok(credentials.clone());
+    }
+
     validate_refresh_token(credentials)?;
 
     // 根据 auth_method 选择刷新方式
@@ -841,6 +846,19 @@ impl MultiTokenManager {
         id: u64,
         credentials: &KiroCredentials,
     ) -> anyhow::Result<CallContext> {
+        // API Key 凭据直接使用 kiro_api_key 作为 Bearer Token，无需刷新
+        if credentials.is_api_key_credential() {
+            let token = credentials
+                .kiro_api_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("API Key 凭据缺少 kiroApiKey"))?;
+            return Ok(CallContext {
+                id,
+                credentials: credentials.clone(),
+                token,
+            });
+        }
+
         // 第一次检查（无锁）：快速判断是否需要刷新
         let needs_refresh = is_token_expired(credentials) || is_token_expiring_soon(credentials);
 
@@ -1349,16 +1367,35 @@ impl MultiTokenManager {
                     priority: e.credentials.priority,
                     disabled: e.disabled,
                     failure_count: e.failure_count,
-                    auth_method: e.credentials.auth_method.as_deref().map(|m| {
-                        if m.eq_ignore_ascii_case("builder-id") || m.eq_ignore_ascii_case("iam") {
-                            "idc".to_string()
-                        } else {
-                            m.to_string()
-                        }
-                    }),
+                    auth_method: if e.credentials.is_api_key_credential() {
+                        Some("api_key".to_string())
+                    } else {
+                        e.credentials.auth_method.as_deref().map(|m| {
+                            if m.eq_ignore_ascii_case("builder-id") || m.eq_ignore_ascii_case("iam") {
+                                "idc".to_string()
+                            } else {
+                                m.to_string()
+                            }
+                        })
+                    },
                     has_profile_arn: e.credentials.profile_arn.is_some(),
-                    expires_at: e.credentials.expires_at.clone(),
-                    refresh_token_hash: e.credentials.refresh_token.as_deref().map(sha256_hex),
+                    expires_at: if e.credentials.is_api_key_credential() {
+                        None // API Key 不过期
+                    } else {
+                        e.credentials.expires_at.clone()
+                    },
+                    refresh_token_hash: if e.credentials.is_api_key_credential() {
+                        // API Key 凭据显示脱敏的 key
+                        e.credentials.kiro_api_key.as_deref().map(|k| {
+                            if k.len() > 8 {
+                                format!("{}...{}", &k[..8], &k[k.len()-4..])
+                            } else {
+                                "***".to_string()
+                            }
+                        })
+                    } else {
+                        e.credentials.refresh_token.as_deref().map(sha256_hex)
+                    },
                     email: e.credentials.email.clone(),
                     success_count: e.success_count,
                     last_used_at: e.last_used_at.clone(),

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1492,6 +1492,12 @@ impl MultiTokenManager {
                 .iter_mut()
                 .find(|e| e.id == id)
                 .ok_or_else(|| anyhow::anyhow!("凭据不存在: {}", id))?;
+            if entry.disabled_reason == Some(DisabledReason::InvalidConfig) {
+                anyhow::bail!(
+                    "凭据 #{} 因配置无效被禁用，请修正配置后重启服务",
+                    id
+                );
+            }
             entry.failure_count = 0;
             entry.refresh_failure_count = 0;
             entry.disabled = false;

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -416,6 +416,8 @@ enum DisabledReason {
     QuotaExceeded,
     /// Refresh Token 永久失效（服务端返回 invalid_grant）
     InvalidRefreshToken,
+    /// 凭据配置无效（如 authMethod=api_key 但缺少 kiroApiKey）
+    InvalidConfig,
 }
 
 /// 统计数据持久化条目
@@ -584,6 +586,26 @@ impl MultiTokenManager {
             })
             .collect();
 
+        // 校验 API Key 凭据配置完整性：authMethod=api_key 时必须提供 kiroApiKey
+        let mut entries = entries;
+        for entry in &mut entries {
+            if entry.credentials.kiro_api_key.is_none()
+                && entry
+                    .credentials
+                    .auth_method
+                    .as_deref()
+                    .map(|m| m.eq_ignore_ascii_case("api_key") || m.eq_ignore_ascii_case("apikey"))
+                    .unwrap_or(false)
+            {
+                tracing::warn!(
+                    "凭据 #{} 配置了 authMethod=api_key 但缺少 kiroApiKey 字段，已自动禁用",
+                    entry.id
+                );
+                entry.disabled = true;
+                entry.disabled_reason = Some(DisabledReason::InvalidConfig);
+            }
+        }
+
         // 检测重复 ID
         let mut seen_ids = std::collections::HashSet::new();
         let mut duplicate_ids = Vec::new();
@@ -596,9 +618,10 @@ impl MultiTokenManager {
             anyhow::bail!("检测到重复的凭据 ID: {:?}", duplicate_ids);
         }
 
-        // 选择初始凭据：优先级最高（priority 最小）的凭据，无凭据时为 0
+        // 选择初始凭据：优先级最高（priority 最小）的可用凭据，无可用凭据时为 0
         let initial_id = entries
             .iter()
+            .filter(|e| !e.disabled)
             .min_by_key(|e| e.credentials.priority)
             .map(|e| e.id)
             .unwrap_or(0);
@@ -1408,6 +1431,7 @@ impl MultiTokenManager {
                         DisabledReason::TooManyRefreshFailures => "TooManyRefreshFailures",
                         DisabledReason::QuotaExceeded => "QuotaExceeded",
                         DisabledReason::InvalidRefreshToken => "InvalidRefreshToken",
+                        DisabledReason::InvalidConfig => "InvalidConfig",
                     }.to_string()),
                 })
                 .collect(),
@@ -1966,6 +1990,38 @@ mod tests {
             "错误消息应包含 '重复的凭据 ID'，实际: {}",
             err_msg
         );
+    }
+
+    #[test]
+    fn test_multi_token_manager_api_key_missing_kiro_api_key_auto_disabled() {
+        let config = Config::default();
+
+        // auth_method=api_key 但缺少 kiro_api_key → 应被自动禁用
+        let mut bad_cred = KiroCredentials::default();
+        bad_cred.auth_method = Some("api_key".to_string());
+        // kiro_api_key 保持 None
+
+        let mut good_cred = KiroCredentials::default();
+        good_cred.refresh_token = Some("valid_token".to_string());
+
+        let manager =
+            MultiTokenManager::new(config, vec![bad_cred, good_cred], None, None, false).unwrap();
+        assert_eq!(manager.total_count(), 2);
+        assert_eq!(manager.available_count(), 1); // bad_cred 被禁用，只剩 1 个可用
+    }
+
+    #[test]
+    fn test_multi_token_manager_api_key_with_kiro_api_key_not_disabled() {
+        let config = Config::default();
+
+        // auth_method=api_key 且有 kiro_api_key → 不应被禁用
+        let mut cred = KiroCredentials::default();
+        cred.auth_method = Some("api_key".to_string());
+        cred.kiro_api_key = Some("ksk_test123".to_string());
+
+        let manager = MultiTokenManager::new(config, vec![cred], None, None, false).unwrap();
+        assert_eq!(manager.total_count(), 1);
+        assert_eq!(manager.available_count(), 1);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,22 @@ async fn main() {
     let is_multiple_format = credentials_config.is_multiple();
 
     // 转换为按优先级排序的凭据列表
-    let credentials_list = credentials_config.into_sorted_credentials();
+    let mut credentials_list = credentials_config.into_sorted_credentials();
+
+    // 检查 KIRO_API_KEY 环境变量，自动创建 API Key 凭据
+    if let Ok(kiro_api_key) = std::env::var("KIRO_API_KEY") {
+        if !kiro_api_key.is_empty() {
+            tracing::info!("检测到 KIRO_API_KEY 环境变量，添加 API Key 凭据（最高优先级）");
+            let api_key_cred = KiroCredentials {
+                kiro_api_key: Some(kiro_api_key),
+                auth_method: Some("api_key".to_string()),
+                priority: 0,
+                ..Default::default()
+            };
+            credentials_list.insert(0, api_key_cred);
+        }
+    }
+
     tracing::info!("已加载 {} 个凭据配置", credentials_list.len());
 
     // 获取第一个凭据用于日志显示


### PR DESCRIPTION
参考：Kiro 的 Changelog，现在引入了 headless 模式可以直接生成 Api key 来认证。

https://kiro.dev/changelog/cli/2-0#headless-mode

## 概述
支持 Kiro CLI headless 模式的 API Key (`KIRO_API_KEY`) 作为新的凭据类型，解决当前需要手动从 IDE 提取 refresh token 的痛点。

## 实现原理
通过逆向分析 kiro-cli 二进制，发现 `KIRO_API_KEY` 直接作为 Bearer Token 发送到 `q.{region}.amazonaws.com`，内部 `TokenType` 为 `API_KEY`。因此无需 token 交换端点，实现非常简洁。

## 变更内容
- `credentials.rs` — 新增 `kiroApiKey` 字段和 `is_api_key_credential()` 方法，`canonicalize_auth_method` 支持 `api_key` 类型
- `token_manager.rs` — API Key 凭据跳过 refresh token 刷新流程，直接使用 API Key 作为 Bearer Token；Admin 快照展示脱敏的 API Key
- `provider.rs` — API Key 凭据请求添加 `tokentype: API_KEY` 头部标识
- `machine_id.rs` — 支持从 API Key 派生 machineId
- `main.rs` — 启动时检测 `KIRO_API_KEY` 环境变量，自动创建最高优先级凭据

## 使用方式
**环境变量（推荐）：**
```bash
KIRO_API_KEY=ksk_xxx ./kiro-rs
```

配置文件：
```json
{
    "kiroApiKey": "ksk_xxx",
    "authMethod": "api_key"
}
```

## 测试
- 编译通过，191 个单元测试全部通过
- API Key 凭据可与现有 social/idc 凭据共存，优先级最高