### PR TITLE
Feature/rpm limit

### DIFF
--- a/.codex/skills/build-kiro-rs-image/SKILL.md
+++ b/.codex/skills/build-kiro-rs-image/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: build-kiro-rs-image
+description: Build or push the Docker image for the current kiro.rs repository as a linux/amd64 image, defaulting to lihengcn/kiro-rs:latest, without performing docker login.
+---
+
+# Build Kiro.rs Image
+
+Use this skill when the user wants to package the current `kiro.rs` repository into a Docker image, especially when they mention:
+
+- `lihengcn/kiro-rs:latest`
+- `x86`
+- `amd64`
+- `docker buildx`
+- `推送镜像`
+
+Assume the user has already completed `docker login`. Do not include login steps unless the user explicitly asks for them.
+
+## Execution-first mode
+
+When this skill is triggered, prefer direct execution over explanation.
+
+- Default to running the bundled script immediately.
+- Do not restate the skill body to the user.
+- Do not provide manual command alternatives unless the user explicitly asks.
+- Do not add extra analysis or long explanations unless execution fails.
+- Keep commentary minimal: one short progress update before running, then report the result.
+
+## Default behavior
+
+- Image: `lihengcn/kiro-rs:latest`
+- Platform: `linux/amd64`
+- Output: push to registry
+- Context: current repository root
+
+## Preferred workflow
+
+1. Run the bundled script from the repository root:
+
+```bash
+.codex/skills/build-kiro-rs-image/scripts/build.sh
+```
+
+2. If the user wants a local image instead of pushing, switch to:
+
+```bash
+OUTPUT_MODE=load .codex/skills/build-kiro-rs-image/scripts/build.sh
+```
+
+3. Only if execution fails unexpectedly, inspect `Dockerfile` or the script to diagnose.
+
+## Supported overrides
+
+Use environment variables when the user wants a different target:
+
+```bash
+IMAGE_REPO=lihengcn/kiro-rs \
+IMAGE_TAG=latest \
+PLATFORM=linux/amd64 \
+OUTPUT_MODE=push \
+.codex/skills/build-kiro-rs-image/scripts/build.sh
+```
+
+## Notes
+
+- `x86` for Docker image builds should be treated as `linux/amd64`.
+- The script will create or reuse a `buildx` builder named `kiro-rs-builder`.
+- The bundled script can locate the repository root automatically.
+- If the user asks for manual commands instead of running the script, provide the equivalent `docker buildx build` command and omit `docker login` by default.

--- a/.codex/skills/build-kiro-rs-image/scripts/build.sh
+++ b/.codex/skills/build-kiro-rs-image/scripts/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+IMAGE_REPO="${IMAGE_REPO:-lihengcn/kiro-rs}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+PLATFORM="${PLATFORM:-linux/amd64}"
+OUTPUT_MODE="${OUTPUT_MODE:-push}"
+BUILDER_NAME="${BUILDER_NAME:-kiro-rs-builder}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+if [[ ! -f "${REPO_ROOT}/Dockerfile" ]]; then
+  echo "未找到 Dockerfile: ${REPO_ROOT}/Dockerfile" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "未找到 docker 命令" >&2
+  exit 1
+fi
+
+if ! docker buildx version >/dev/null 2>&1; then
+  echo "当前 Docker 不支持 buildx" >&2
+  exit 1
+fi
+
+if docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+  docker buildx use "${BUILDER_NAME}" >/dev/null
+else
+  docker buildx create --name "${BUILDER_NAME}" --use >/dev/null
+fi
+
+docker buildx inspect --bootstrap >/dev/null
+
+case "${OUTPUT_MODE}" in
+  push)
+    OUTPUT_FLAG="--push"
+    ;;
+  load)
+    OUTPUT_FLAG="--load"
+    ;;
+  *)
+    echo "不支持的 OUTPUT_MODE: ${OUTPUT_MODE}，可选值为 push 或 load" >&2
+    exit 1
+    ;;
+esac
+
+cd "${REPO_ROOT}"
+
+echo "开始构建镜像 ${IMAGE_REPO}:${IMAGE_TAG}"
+echo "目标平台: ${PLATFORM}"
+echo "输出模式: ${OUTPUT_MODE}"
+
+docker buildx build \
+  --platform "${PLATFORM}" \
+  -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+  "${OUTPUT_FLAG}" \
+  "$@" \
+  .

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - **Admin 管理**: 可选的 Web 管理界面和 API，支持凭据管理、余额查询等
 - **多级 Region 配置**: 支持全局和凭据级别的 Auth Region / API Region 配置
 - **凭据级代理**: 支持为每个凭据单独配置 HTTP/SOCKS5 代理，优先级：凭据代理 > 全局代理 > 无代理
+- **自定义多窗口限流**: 支持全局默认限流和凭据级覆盖，时间窗口支持 `30s` / `5m` / `2h` / `1d` 等自定义配置
 
 ---
 
@@ -189,6 +190,7 @@ docker-compose up
 | `proxyUsername` | string | - | 代理用户名 |
 | `proxyPassword` | string | - | 代理密码 |
 | `adminApiKey` | string | - | Admin API 密钥，配置后启用凭据管理 API 和 Web 管理界面 |
+| `defaultRateLimits` | array | - | 全局默认限流规则（作为每个凭据的默认值） |
 | `loadBalancingMode` | string | `priority` | 负载均衡模式：`priority`（按优先级）或 `balanced`（均衡分配） |
 | `extractThinking` | boolean | `true` | 非流式响应的 thinking 块提取。启用后 `<thinking>` 标签会被解析为独立的 `thinking` 内容块 |
 
@@ -214,6 +216,10 @@ docker-compose up
    "proxyUsername": "user",
    "proxyPassword": "pass",
    "adminApiKey": "sk-admin-your-secret-key",
+   "defaultRateLimits": [
+      { "window": "5m", "maxRequests": 100 },
+      { "window": "24h", "maxRequests": 3000 }
+   ],
    "loadBalancingMode": "priority",
    "extractThinking": true
 }
@@ -244,6 +250,7 @@ docker-compose up
 | `proxyUrl`     | string | 凭据级代理 URL（可选，特殊值 `direct` 表示不使用代理）       |
 | `proxyUsername`| string | 凭据级代理用户名（可选）                                |
 | `proxyPassword`| string | 凭据级代理密码（可选）                                 |
+| `rateLimits`   | array  | 凭据级限流规则（可选，配置后将整套替代全局默认值）              |
 
 说明：
 - IdC / Builder-ID / IAM 在本项目里属于同一种登录方式，配置时统一使用 `authMethod: "idc"`
@@ -271,7 +278,11 @@ docker-compose up
       "refreshToken": "第一个凭据的刷新token",
       "expiresAt": "2025-12-31T02:32:45.144Z",
       "authMethod": "social",
-      "priority": 0
+      "priority": 0,
+      "rateLimits": [
+         { "window": "2m", "maxRequests": 20 },
+         { "window": "12h", "maxRequests": 800 }
+      ]
    },
    {
       "refreshToken": "第二个凭据的刷新token",
@@ -300,6 +311,60 @@ docker-compose up
 - 单凭据最多重试 3 次，单请求最多重试 9 次
 - 自动故障转移到下一个可用凭据
 - 多凭据格式下 Token 刷新后自动回写到源文件
+
+### 限流配置
+
+支持全局默认限流和凭据级覆盖，规则结构如下：
+
+```json
+{ "window": "5m", "maxRequests": 100 }
+```
+
+- `window` 支持自定义时间窗口，格式为 `正整数 + 单位`
+- 单位支持：`s`（秒）、`m`（分钟）、`h`（小时）、`d`（天）
+- 示例：`30s`、`5m`、`90m`、`2h`、`1d`
+- `maxRequests` 必须大于 0
+
+生效规则：
+
+- `config.defaultRateLimits` 是全局默认值
+- 如果凭据未配置 `rateLimits`，则使用全局默认值
+- 如果凭据配置了 `rateLimits`，则整套使用凭据自己的规则，完全忽略全局默认值
+- 多条规则按“且”生效，任一窗口超限则该凭据暂时不可用
+- 当某个凭据限流时，系统会自动切换到其他可用凭据；如果全部凭据都被限流，请求会等待最早恢复的凭据而不是直接报错
+- 仅真实上游请求计入限流：`/generateAssistantResponse` 和 `/mcp`
+- Token 刷新、余额查询、Admin API 不计入限流
+
+示例：
+
+```json
+{
+   "defaultRateLimits": [
+      { "window": "5m", "maxRequests": 100 },
+      { "window": "24h", "maxRequests": 3000 }
+   ]
+}
+```
+
+```json
+[
+   {
+      "refreshToken": "凭据A",
+      "rateLimits": [
+         { "window": "2m", "maxRequests": 20 },
+         { "window": "1d", "maxRequests": 2000 }
+      ]
+   },
+   {
+      "refreshToken": "凭据B"
+   }
+]
+```
+
+上面配置下：
+
+- 凭据 A 生效规则为：`2m=20`、`1d=2000`
+- 凭据 B 生效规则为：`5m=100`、`24h=3000`
 
 ### Region 配置
 
@@ -450,8 +515,13 @@ RUST_LOG=debug ./target/release/kiro-rs
   - `DELETE /api/admin/credentials/:id` - 删除凭据
   - `POST /api/admin/credentials/:id/disabled` - 设置凭据禁用状态
   - `POST /api/admin/credentials/:id/priority` - 设置凭据优先级
+  - `POST /api/admin/credentials/:id/rate-limits` - 设置凭据级限流规则
   - `POST /api/admin/credentials/:id/reset` - 重置失败计数
   - `GET /api/admin/credentials/:id/balance` - 获取凭据余额
+  - `GET /api/admin/config/rate-limits` - 获取全局默认限流规则
+  - `PUT /api/admin/config/rate-limits` - 设置全局默认限流规则
+  - `GET /api/admin/config/load-balancing` - 获取负载均衡模式
+  - `PUT /api/admin/config/load-balancing` - 设置负载均衡模式
 
 - **Admin UI**
   - `GET /admin` - 访问管理页面（需要在编译前构建 `admin-ui/dist`）

--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -8,6 +8,8 @@ import type {
   SetPriorityRequest,
   AddCredentialRequest,
   AddCredentialResponse,
+  DefaultRateLimitsResponse,
+  RateLimitRule,
 } from '@/types/api'
 
 // 创建 axios 实例
@@ -57,6 +59,18 @@ export async function setCredentialPriority(
   return data
 }
 
+// 设置凭据限流规则
+export async function setCredentialRateLimits(
+  id: number,
+  rateLimits?: RateLimitRule[]
+): Promise<SuccessResponse> {
+  const { data } = await api.post<SuccessResponse>(
+    `/credentials/${id}/rate-limits`,
+    { rateLimits }
+  )
+  return data
+}
+
 // 重置失败计数
 export async function resetCredentialFailure(
   id: number
@@ -102,5 +116,21 @@ export async function getLoadBalancingMode(): Promise<{ mode: 'priority' | 'bala
 // 设置负载均衡模式
 export async function setLoadBalancingMode(mode: 'priority' | 'balanced'): Promise<{ mode: 'priority' | 'balanced' }> {
   const { data } = await api.put<{ mode: 'priority' | 'balanced' }>('/config/load-balancing', { mode })
+  return data
+}
+
+// 获取全局默认限流规则
+export async function getDefaultRateLimits(): Promise<DefaultRateLimitsResponse> {
+  const { data } = await api.get<DefaultRateLimitsResponse>('/config/rate-limits')
+  return data
+}
+
+// 设置全局默认限流规则
+export async function setDefaultRateLimits(
+  defaultRateLimits?: RateLimitRule[]
+): Promise<DefaultRateLimitsResponse> {
+  const { data } = await api.put<DefaultRateLimitsResponse>('/config/rate-limits', {
+    defaultRateLimits,
+  })
   return data
 }

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -25,7 +25,6 @@ import {
   useDeleteCredential,
   useForceRefreshToken,
 } from '@/hooks/use-credentials'
-import type { RateLimitRule } from '@/types/api'
 
 interface CredentialCardProps {
   credential: CredentialStatusItem
@@ -52,16 +51,45 @@ function formatLastUsed(lastUsedAt: string | null): string {
   return `${days} 天前`
 }
 
-function formatRateLimits(rateLimits?: RateLimitRule[]): string {
-  if (!rateLimits || rateLimits.length === 0) return '未配置'
-  return rateLimits
-    .map((rule) => `${rule.window} / ${rule.maxRequests}`)
-    .join('，')
+function formatTimeUntil(value?: string): string {
+  if (!value) return ''
+  const diffMs = new Date(value).getTime() - Date.now()
+  if (diffMs <= 0) return '即将'
+
+  const totalSeconds = Math.ceil(diffMs / 1000)
+  if (totalSeconds < 60) return `${totalSeconds} 秒`
+
+  const totalMinutes = Math.ceil(totalSeconds / 60)
+  if (totalMinutes < 60) return `${totalMinutes} 分钟`
+
+  const totalHours = Math.ceil(totalMinutes / 60)
+  if (totalHours < 24) return `${totalHours} 小时`
+
+  const totalDays = Math.ceil(totalHours / 24)
+  return `${totalDays} 天`
 }
 
-function formatDateTime(value?: string): string {
-  if (!value) return '-'
-  return new Date(value).toLocaleString()
+function formatRateLimitStatusDetail(credential: CredentialStatusItem): string | null {
+  const summaries = credential.rateLimitSummaries?.slice(0, 2) ?? []
+  const fallbackSummary = credential.rateLimitSummary
+  const effectiveSummaries = summaries.length > 0 ? summaries : fallbackSummary ? [fallbackSummary] : []
+  if (effectiveSummaries.length === 0) return null
+
+  if (credential.rateLimited) {
+    const wait = formatTimeUntil(credential.nextAvailableAt)
+    const [first, second] = effectiveSummaries
+    const parts = [
+      wait ? `${first.window} 已打满，${wait}后恢复` : `${first.window} 已打满`,
+    ]
+    if (second) {
+      parts.push(`${second.window} 剩余 ${second.remainingRequests}/${second.maxRequests}`)
+    }
+    return parts.join('；')
+  }
+
+  return effectiveSummaries
+    .map((summary) => `${summary.window} 剩余 ${summary.remainingRequests}/${summary.maxRequests}`)
+    .join('，')
 }
 
 export function CredentialCard({
@@ -83,6 +111,7 @@ export function CredentialCard({
   const resetFailure = useResetFailure()
   const deleteCredential = useDeleteCredential()
   const forceRefresh = useForceRefreshToken()
+  const rateLimitStatusDetail = formatRateLimitStatusDetail(credential)
 
   const handleToggleDisabled = () => {
     setDisabled.mutate(
@@ -261,24 +290,17 @@ export function CredentialCard({
               <span className="font-medium">{credential.successCount}</span>
             </div>
             <div>
+              <span className="text-muted-foreground">最后调用：</span>
+              <span className="font-medium">{formatLastUsed(credential.lastUsedAt)}</span>
+            </div>
+            <div className="col-span-2">
               <span className="text-muted-foreground">限流状态：</span>
               <span className={credential.rateLimited ? 'text-amber-600 font-medium' : 'font-medium'}>
                 {credential.rateLimited ? '限流中' : '正常'}
               </span>
-            </div>
-            <div className="col-span-2">
-              <span className="text-muted-foreground">最后调用：</span>
-              <span className="font-medium">{formatLastUsed(credential.lastUsedAt)}</span>
-            </div>
-            {credential.rateLimited && credential.nextAvailableAt && (
-              <div className="col-span-2">
-                <span className="text-muted-foreground">恢复时间：</span>
-                <span className="font-medium">{formatDateTime(credential.nextAvailableAt)}</span>
-              </div>
-            )}
-            <div className="col-span-2">
-              <span className="text-muted-foreground">限流规则：</span>
-              <span className="font-medium">{formatRateLimits(credential.effectiveRateLimits)}</span>
+              {rateLimitStatusDetail && (
+                <span className="text-muted-foreground">（{rateLimitStatusDetail}）</span>
+              )}
             </div>
             <div className="col-span-2">
               <span className="text-muted-foreground">剩余用量：</span>

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
+import { RateLimitDialog } from '@/components/rate-limit-dialog'
 import {
   Dialog,
   DialogContent,
@@ -19,10 +20,12 @@ import type { CredentialStatusItem, BalanceResponse } from '@/types/api'
 import {
   useSetDisabled,
   useSetPriority,
+  useSetCredentialRateLimits,
   useResetFailure,
   useDeleteCredential,
   useForceRefreshToken,
 } from '@/hooks/use-credentials'
+import type { RateLimitRule } from '@/types/api'
 
 interface CredentialCardProps {
   credential: CredentialStatusItem
@@ -49,6 +52,18 @@ function formatLastUsed(lastUsedAt: string | null): string {
   return `${days} 天前`
 }
 
+function formatRateLimits(rateLimits?: RateLimitRule[]): string {
+  if (!rateLimits || rateLimits.length === 0) return '未配置'
+  return rateLimits
+    .map((rule) => `${rule.window} / ${rule.maxRequests}`)
+    .join('，')
+}
+
+function formatDateTime(value?: string): string {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+
 export function CredentialCard({
   credential,
   onViewBalance,
@@ -60,9 +75,11 @@ export function CredentialCard({
   const [editingPriority, setEditingPriority] = useState(false)
   const [priorityValue, setPriorityValue] = useState(String(credential.priority))
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [showRateLimitDialog, setShowRateLimitDialog] = useState(false)
 
   const setDisabled = useSetDisabled()
   const setPriority = useSetPriority()
+  const setCredentialRateLimits = useSetCredentialRateLimits()
   const resetFailure = useResetFailure()
   const deleteCredential = useDeleteCredential()
   const forceRefresh = useForceRefreshToken()
@@ -243,9 +260,25 @@ export function CredentialCard({
               <span className="text-muted-foreground">成功次数：</span>
               <span className="font-medium">{credential.successCount}</span>
             </div>
+            <div>
+              <span className="text-muted-foreground">限流状态：</span>
+              <span className={credential.rateLimited ? 'text-amber-600 font-medium' : 'font-medium'}>
+                {credential.rateLimited ? '限流中' : '正常'}
+              </span>
+            </div>
             <div className="col-span-2">
               <span className="text-muted-foreground">最后调用：</span>
               <span className="font-medium">{formatLastUsed(credential.lastUsedAt)}</span>
+            </div>
+            {credential.rateLimited && credential.nextAvailableAt && (
+              <div className="col-span-2">
+                <span className="text-muted-foreground">恢复时间：</span>
+                <span className="font-medium">{formatDateTime(credential.nextAvailableAt)}</span>
+              </div>
+            )}
+            <div className="col-span-2">
+              <span className="text-muted-foreground">限流规则：</span>
+              <span className="font-medium">{formatRateLimits(credential.effectiveRateLimits)}</span>
             </div>
             <div className="col-span-2">
               <span className="text-muted-foreground">剩余用量：</span>
@@ -297,6 +330,14 @@ export function CredentialCard({
             >
               <RefreshCw className={`h-4 w-4 mr-1 ${forceRefresh.isPending ? 'animate-spin' : ''}`} />
               刷新 Token
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setShowRateLimitDialog(true)}
+              disabled={setCredentialRateLimits.isPending}
+            >
+              编辑限流
             </Button>
             <Button
               size="sm"
@@ -383,6 +424,29 @@ export function CredentialCard({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <RateLimitDialog
+        open={showRateLimitDialog}
+        onOpenChange={setShowRateLimitDialog}
+        title={`编辑凭据 #${credential.id} 限流`}
+        description="这里只配置该凭据自己的限流规则。留空保存会移除凭据级规则，回退到全局默认限流。"
+        initialRules={credential.rateLimits}
+        loading={setCredentialRateLimits.isPending}
+        onSave={(rules) => {
+          setCredentialRateLimits.mutate(
+            { id: credential.id, rateLimits: rules },
+            {
+              onSuccess: (res) => {
+                toast.success(res.message)
+                setShowRateLimitDialog(false)
+              },
+              onError: (err) => {
+                toast.error('操作失败: ' + (err as Error).message)
+              },
+            }
+          )
+        }}
+      />
     </>
   )
 }

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -12,7 +12,16 @@ import { AddCredentialDialog } from '@/components/add-credential-dialog'
 import { BatchImportDialog } from '@/components/batch-import-dialog'
 import { KamImportDialog } from '@/components/kam-import-dialog'
 import { BatchVerifyDialog, type VerifyResult } from '@/components/batch-verify-dialog'
-import { useCredentials, useDeleteCredential, useResetFailure, useLoadBalancingMode, useSetLoadBalancingMode } from '@/hooks/use-credentials'
+import { RateLimitDialog } from '@/components/rate-limit-dialog'
+import {
+  useCredentials,
+  useDefaultRateLimits,
+  useDeleteCredential,
+  useResetFailure,
+  useLoadBalancingMode,
+  useSetDefaultRateLimits,
+  useSetLoadBalancingMode,
+} from '@/hooks/use-credentials'
 import { getCredentialBalance, forceRefreshToken } from '@/api/credentials'
 import { extractErrorMessage } from '@/lib/utils'
 import type { BalanceResponse } from '@/types/api'
@@ -38,6 +47,7 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const [queryInfoProgress, setQueryInfoProgress] = useState({ current: 0, total: 0 })
   const [batchRefreshing, setBatchRefreshing] = useState(false)
   const [batchRefreshProgress, setBatchRefreshProgress] = useState({ current: 0, total: 0 })
+  const [rateLimitDialogOpen, setRateLimitDialogOpen] = useState(false)
   const cancelVerifyRef = useRef(false)
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 12
@@ -54,6 +64,8 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const { mutate: resetFailure } = useResetFailure()
   const { data: loadBalancingData, isLoading: isLoadingMode } = useLoadBalancingMode()
   const { mutate: setLoadBalancingMode, isPending: isSettingMode } = useSetLoadBalancingMode()
+  const { data: defaultRateLimitsData } = useDefaultRateLimits()
+  const { mutate: setDefaultRateLimits, isPending: isSettingRateLimits } = useSetDefaultRateLimits()
 
   // 计算分页
   const totalPages = Math.ceil((data?.credentials.length || 0) / itemsPerPage)
@@ -548,6 +560,15 @@ export function Dashboard({ onLogout }: DashboardProps) {
             <Button
               variant="outline"
               size="sm"
+              onClick={() => setRateLimitDialogOpen(true)}
+              disabled={isSettingRateLimits}
+              title="编辑全局默认限流"
+            >
+              全局限流
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
               onClick={handleToggleLoadBalancing}
               disabled={isLoadingMode || isSettingMode}
               title="切换负载均衡模式"
@@ -780,6 +801,26 @@ export function Dashboard({ onLogout }: DashboardProps) {
         progress={verifyProgress}
         results={verifyResults}
         onCancel={handleCancelVerify}
+      />
+
+      <RateLimitDialog
+        open={rateLimitDialogOpen}
+        onOpenChange={setRateLimitDialogOpen}
+        title="全局默认限流"
+        description="这里配置未单独设置限流规则的凭据所使用的默认限流。只要凭据自己配置了规则，就会完全忽略全局默认限流。"
+        initialRules={defaultRateLimitsData?.defaultRateLimits}
+        loading={isSettingRateLimits}
+        onSave={(rules) => {
+          setDefaultRateLimits(rules, {
+            onSuccess: () => {
+              toast.success('全局默认限流规则已更新')
+              setRateLimitDialogOpen(false)
+            },
+            onError: (error) => {
+              toast.error(`更新失败: ${extractErrorMessage(error)}`)
+            },
+          })
+        }}
       />
     </div>
   )

--- a/admin-ui/src/components/rate-limit-dialog.tsx
+++ b/admin-ui/src/components/rate-limit-dialog.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { RateLimitRule } from '@/types/api'
+
+interface EditableRateLimitRule {
+  window: string
+  maxRequests: string
+}
+
+interface RateLimitDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  initialRules?: RateLimitRule[]
+  loading?: boolean
+  onSave: (rules?: RateLimitRule[]) => void
+}
+
+function toEditableRules(rules?: RateLimitRule[]): EditableRateLimitRule[] {
+  if (!rules || rules.length === 0) {
+    return [{ window: '', maxRequests: '' }]
+  }
+
+  return rules.map((rule) => ({
+    window: rule.window,
+    maxRequests: String(rule.maxRequests),
+  }))
+}
+
+export function RateLimitDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  initialRules,
+  loading = false,
+  onSave,
+}: RateLimitDialogProps) {
+  const [rules, setRules] = useState<EditableRateLimitRule[]>(toEditableRules(initialRules))
+
+  useEffect(() => {
+    if (open) {
+      setRules(toEditableRules(initialRules))
+    }
+  }, [initialRules, open])
+
+  const updateRule = (index: number, key: keyof EditableRateLimitRule, value: string) => {
+    setRules((prev) => prev.map((rule, idx) => (
+      idx === index ? { ...rule, [key]: value } : rule
+    )))
+  }
+
+  const handleSave = () => {
+    const normalized = rules
+      .map((rule) => ({
+        window: rule.window.trim(),
+        maxRequests: rule.maxRequests.trim(),
+      }))
+      .filter((rule) => rule.window !== '' || rule.maxRequests !== '')
+
+    if (normalized.some((rule) => rule.window === '' || rule.maxRequests === '')) {
+      toast.error('时间窗口和最大请求数必须同时填写')
+      return
+    }
+
+    const parsed = normalized.map((rule) => ({
+      window: rule.window,
+      maxRequests: Number.parseInt(rule.maxRequests, 10),
+    }))
+
+    if (parsed.some((rule) => Number.isNaN(rule.maxRequests) || rule.maxRequests <= 0)) {
+      toast.error('最大请求数必须是正整数')
+      return
+    }
+
+    onSave(parsed.length > 0 ? parsed : undefined)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {rules.map((rule, index) => (
+            <div key={index} className="grid grid-cols-[1fr_1fr_auto] gap-2">
+              <Input
+                value={rule.window}
+                onChange={(e) => updateRule(index, 'window', e.target.value)}
+                placeholder="例如 5m、30s、2h"
+                disabled={loading}
+              />
+              <Input
+                type="number"
+                min="1"
+                value={rule.maxRequests}
+                onChange={(e) => updateRule(index, 'maxRequests', e.target.value)}
+                placeholder="最大请求数"
+                disabled={loading}
+              />
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setRules((prev) => {
+                    if (prev.length === 1) {
+                      return [{ window: '', maxRequests: '' }]
+                    }
+                    return prev.filter((_, idx) => idx !== index)
+                  })
+                }}
+                disabled={loading}
+              >
+                删除
+              </Button>
+            </div>
+          ))}
+
+          <Button
+            variant="outline"
+            onClick={() => setRules((prev) => [...prev, { window: '', maxRequests: '' }])}
+            disabled={loading}
+          >
+            添加规则
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            支持自定义窗口，例如 `30s`、`5m`、`2h`、`1d`。留空并保存可清空当前覆盖规则。
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            取消
+          </Button>
+          <Button onClick={handleSave} disabled={loading}>
+            保存
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -3,6 +3,7 @@ import {
   getCredentials,
   setCredentialDisabled,
   setCredentialPriority,
+  setCredentialRateLimits,
   resetCredentialFailure,
   forceRefreshToken,
   getCredentialBalance,
@@ -10,8 +11,10 @@ import {
   deleteCredential,
   getLoadBalancingMode,
   setLoadBalancingMode,
+  getDefaultRateLimits,
+  setDefaultRateLimits,
 } from '@/api/credentials'
-import type { AddCredentialRequest } from '@/types/api'
+import type { AddCredentialRequest, RateLimitRule } from '@/types/api'
 
 // 查询凭据列表
 export function useCredentials() {
@@ -50,6 +53,18 @@ export function useSetPriority() {
   return useMutation({
     mutationFn: ({ id, priority }: { id: number; priority: number }) =>
       setCredentialPriority(id, priority),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
+  })
+}
+
+// 设置凭据限流规则
+export function useSetCredentialRateLimits() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, rateLimits }: { id: number; rateLimits?: RateLimitRule[] }) =>
+      setCredentialRateLimits(id, rateLimits),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['credentials'] })
     },
@@ -108,6 +123,14 @@ export function useLoadBalancingMode() {
   })
 }
 
+// 获取全局默认限流规则
+export function useDefaultRateLimits() {
+  return useQuery({
+    queryKey: ['defaultRateLimits'],
+    queryFn: getDefaultRateLimits,
+  })
+}
+
 // 设置负载均衡模式
 export function useSetLoadBalancingMode() {
   const queryClient = useQueryClient()
@@ -115,6 +138,18 @@ export function useSetLoadBalancingMode() {
     mutationFn: setLoadBalancingMode,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['loadBalancingMode'] })
+    },
+  })
+}
+
+// 设置全局默认限流规则
+export function useSetDefaultRateLimits() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: setDefaultRateLimits,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['defaultRateLimits'] })
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
     },
   })
 }

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -33,6 +33,14 @@ export interface CredentialStatusItem {
   effectiveRateLimits: RateLimitRule[]
   rateLimited: boolean
   nextAvailableAt?: string
+  rateLimitSummary?: RateLimitSummary
+  rateLimitSummaries: RateLimitSummary[]
+}
+
+export interface RateLimitSummary {
+  window: string
+  maxRequests: number
+  remainingRequests: number
 }
 
 // 余额响应

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -1,3 +1,8 @@
+export interface RateLimitRule {
+  window: string
+  maxRequests: number
+}
+
 // 凭据状态响应
 export interface CredentialsStatusResponse {
   total: number
@@ -24,6 +29,10 @@ export interface CredentialStatusItem {
   proxyUrl?: string
   refreshFailureCount: number
   disabledReason?: string
+  rateLimits?: RateLimitRule[]
+  effectiveRateLimits: RateLimitRule[]
+  rateLimited: boolean
+  nextAvailableAt?: string
 }
 
 // 余额响应
@@ -73,6 +82,7 @@ export interface AddCredentialRequest {
   proxyUrl?: string
   proxyUsername?: string
   proxyPassword?: string
+  rateLimits?: RateLimitRule[]
 }
 
 // 添加凭据响应
@@ -81,4 +91,8 @@ export interface AddCredentialResponse {
   message: string
   credentialId: number
   email?: string
+}
+
+export interface DefaultRateLimitsResponse {
+  defaultRateLimits?: RateLimitRule[]
 }

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -61,7 +61,10 @@ pub async fn set_credential_rate_limits(
     Path(id): Path<u64>,
     Json(payload): Json<SetRateLimitsRequest>,
 ) -> impl IntoResponse {
-    match state.service.set_credential_rate_limits(id, payload.rate_limits) {
+    match state
+        .service
+        .set_credential_rate_limits(id, payload.rate_limits)
+    {
         Ok(_) => Json(SuccessResponse::new(format!("凭据 #{} 限流规则已更新", id))).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
@@ -166,7 +169,10 @@ pub async fn set_default_rate_limits(
     State(state): State<AdminState>,
     Json(payload): Json<SetDefaultRateLimitsRequest>,
 ) -> impl IntoResponse {
-    match state.service.set_default_rate_limits(payload.default_rate_limits) {
+    match state
+        .service
+        .set_default_rate_limits(payload.default_rate_limits)
+    {
         Ok(response) => Json(response).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -9,8 +9,8 @@ use axum::{
 use super::{
     middleware::AdminState,
     types::{
-        AddCredentialRequest, SetDisabledRequest, SetLoadBalancingModeRequest, SetPriorityRequest,
-        SuccessResponse,
+        AddCredentialRequest, SetDefaultRateLimitsRequest, SetDisabledRequest,
+        SetLoadBalancingModeRequest, SetPriorityRequest, SetRateLimitsRequest, SuccessResponse,
     },
 };
 
@@ -50,6 +50,19 @@ pub async fn set_credential_priority(
             id, payload.priority
         )))
         .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// POST /api/admin/credentials/:id/rate-limits
+/// 设置凭据级限流规则
+pub async fn set_credential_rate_limits(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+    Json(payload): Json<SetRateLimitsRequest>,
+) -> impl IntoResponse {
+    match state.service.set_credential_rate_limits(id, payload.rate_limits) {
+        Ok(_) => Json(SuccessResponse::new(format!("凭据 #{} 限流规则已更新", id))).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
 }
@@ -136,6 +149,24 @@ pub async fn set_load_balancing_mode(
     Json(payload): Json<SetLoadBalancingModeRequest>,
 ) -> impl IntoResponse {
     match state.service.set_load_balancing_mode(payload) {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// GET /api/admin/config/rate-limits
+/// 获取全局默认限流规则
+pub async fn get_default_rate_limits(State(state): State<AdminState>) -> impl IntoResponse {
+    Json(state.service.get_default_rate_limits())
+}
+
+/// PUT /api/admin/config/rate-limits
+/// 设置全局默认限流规则
+pub async fn set_default_rate_limits(
+    State(state): State<AdminState>,
+    Json(payload): Json<SetDefaultRateLimitsRequest>,
+) -> impl IntoResponse {
+    match state.service.set_default_rate_limits(payload.default_rate_limits) {
         Ok(response) => Json(response).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -45,7 +45,10 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/credentials/{id}", delete(delete_credential))
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))
-        .route("/credentials/{id}/rate-limits", post(set_credential_rate_limits))
+        .route(
+            "/credentials/{id}/rate-limits",
+            post(set_credential_rate_limits),
+        )
         .route("/credentials/{id}/reset", post(reset_failure_count))
         .route("/credentials/{id}/refresh", post(force_refresh_token))
         .route("/credentials/{id}/balance", get(get_credential_balance))

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -8,8 +8,9 @@ use axum::{
 use super::{
     handlers::{
         add_credential, delete_credential, force_refresh_token, get_all_credentials,
-        get_credential_balance, get_load_balancing_mode, reset_failure_count,
-        set_credential_disabled, set_credential_priority, set_load_balancing_mode,
+        get_credential_balance, get_default_rate_limits, get_load_balancing_mode,
+        reset_failure_count, set_credential_disabled, set_credential_priority,
+        set_credential_rate_limits, set_default_rate_limits, set_load_balancing_mode,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -22,11 +23,14 @@ use super::{
 /// - `DELETE /credentials/:id` - 删除凭据
 /// - `POST /credentials/:id/disabled` - 设置凭据禁用状态
 /// - `POST /credentials/:id/priority` - 设置凭据优先级
+/// - `POST /credentials/:id/rate-limits` - 设置凭据级限流规则
 /// - `POST /credentials/:id/reset` - 重置失败计数
 /// - `POST /credentials/:id/refresh` - 强制刷新 Token
 /// - `GET /credentials/:id/balance` - 获取凭据余额
 /// - `GET /config/load-balancing` - 获取负载均衡模式
 /// - `PUT /config/load-balancing` - 设置负载均衡模式
+/// - `GET /config/rate-limits` - 获取全局默认限流规则
+/// - `PUT /config/rate-limits` - 设置全局默认限流规则
 ///
 /// # 认证
 /// 需要 Admin API Key 认证，支持：
@@ -41,12 +45,17 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/credentials/{id}", delete(delete_credential))
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))
+        .route("/credentials/{id}/rate-limits", post(set_credential_rate_limits))
         .route("/credentials/{id}/reset", post(reset_failure_count))
         .route("/credentials/{id}/refresh", post(force_refresh_token))
         .route("/credentials/{id}/balance", get(get_credential_balance))
         .route(
             "/config/load-balancing",
             get(get_load_balancing_mode).put(set_load_balancing_mode),
+        )
+        .route(
+            "/config/rate-limits",
+            get(get_default_rate_limits).put(set_default_rate_limits),
         )
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -15,7 +15,7 @@ use super::error::AdminServiceError;
 use super::types::{
     AddCredentialRequest, AddCredentialResponse, BalanceResponse, CredentialStatusItem,
     CredentialsStatusResponse, DefaultRateLimitsResponse, LoadBalancingModeResponse,
-    SetLoadBalancingModeRequest,
+    RateLimitSummary, SetLoadBalancingModeRequest,
 };
 
 /// 余额缓存过期时间（秒），5 分钟
@@ -82,6 +82,20 @@ impl AdminService {
                 effective_rate_limits: entry.effective_rate_limits,
                 rate_limited: entry.rate_limited,
                 next_available_at: entry.next_available_at,
+                rate_limit_summary: entry.rate_limit_summary.map(|summary| RateLimitSummary {
+                    window: summary.window,
+                    max_requests: summary.max_requests,
+                    remaining_requests: summary.remaining_requests,
+                }),
+                rate_limit_summaries: entry
+                    .rate_limit_summaries
+                    .into_iter()
+                    .map(|summary| RateLimitSummary {
+                        window: summary.window,
+                        max_requests: summary.max_requests,
+                        remaining_requests: summary.remaining_requests,
+                    })
+                    .collect(),
             })
             .collect();
 
@@ -448,7 +462,8 @@ impl AdminService {
         let msg = e.to_string();
         if msg.contains("不存在") {
             AdminServiceError::NotFound { id }
-        } else if msg.contains("只能删除已禁用的凭据") || msg.contains("请先禁用凭据") {
+        } else if msg.contains("只能删除已禁用的凭据") || msg.contains("请先禁用凭据")
+        {
             AdminServiceError::InvalidCredential(msg)
         } else {
             AdminServiceError::InternalError(msg)

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -14,7 +14,8 @@ use crate::kiro::token_manager::MultiTokenManager;
 use super::error::AdminServiceError;
 use super::types::{
     AddCredentialRequest, AddCredentialResponse, BalanceResponse, CredentialStatusItem,
-    CredentialsStatusResponse, LoadBalancingModeResponse, SetLoadBalancingModeRequest,
+    CredentialsStatusResponse, DefaultRateLimitsResponse, LoadBalancingModeResponse,
+    SetLoadBalancingModeRequest,
 };
 
 /// 余额缓存过期时间（秒），5 分钟
@@ -77,6 +78,10 @@ impl AdminService {
                 proxy_url: entry.proxy_url,
                 refresh_failure_count: entry.refresh_failure_count,
                 disabled_reason: entry.disabled_reason,
+                rate_limits: entry.rate_limits,
+                effective_rate_limits: entry.effective_rate_limits,
+                rate_limited: entry.rate_limited,
+                next_available_at: entry.next_available_at,
             })
             .collect();
 
@@ -209,6 +214,7 @@ impl AdminService {
             proxy_url: req.proxy_url,
             proxy_username: req.proxy_username,
             proxy_password: req.proxy_password,
+            rate_limits: req.rate_limits,
             disabled: false, // 新添加的凭据默认启用
         };
 
@@ -255,6 +261,12 @@ impl AdminService {
         }
     }
 
+    pub fn get_default_rate_limits(&self) -> DefaultRateLimitsResponse {
+        DefaultRateLimitsResponse {
+            default_rate_limits: self.token_manager.get_default_rate_limits(),
+        }
+    }
+
     /// 设置负载均衡模式
     pub fn set_load_balancing_mode(
         &self,
@@ -272,6 +284,27 @@ impl AdminService {
             .map_err(|e| AdminServiceError::InternalError(e.to_string()))?;
 
         Ok(LoadBalancingModeResponse { mode: req.mode })
+    }
+
+    pub fn set_default_rate_limits(
+        &self,
+        rate_limits: Option<Vec<crate::model::rate_limit::RateLimitRule>>,
+    ) -> Result<DefaultRateLimitsResponse, AdminServiceError> {
+        self.token_manager
+            .set_default_rate_limits(rate_limits)
+            .map_err(|e| AdminServiceError::InvalidCredential(e.to_string()))?;
+
+        Ok(self.get_default_rate_limits())
+    }
+
+    pub fn set_credential_rate_limits(
+        &self,
+        id: u64,
+        rate_limits: Option<Vec<crate::model::rate_limit::RateLimitRule>>,
+    ) -> Result<(), AdminServiceError> {
+        self.token_manager
+            .set_rate_limits(id, rate_limits)
+            .map_err(|e| self.classify_error(e, id))
     }
 
     /// 强制刷新指定凭据的 Token

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -68,6 +68,24 @@ pub struct CredentialStatusItem {
     /// 最早恢复可用时间（RFC3339）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_available_at: Option<String>,
+    /// 当前最紧张的限流窗口摘要
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_summary: Option<RateLimitSummary>,
+    /// 当前最紧张的前两条限流窗口摘要
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub rate_limit_summaries: Vec<RateLimitSummary>,
+}
+
+/// 限流摘要信息
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitSummary {
+    /// 当前最紧张的时间窗口
+    pub window: String,
+    /// 该窗口允许的最大请求数
+    pub max_requests: u32,
+    /// 该窗口剩余可用请求数
+    pub remaining_requests: u32,
 }
 
 // ============ 操作请求 ============

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::model::rate_limit::RateLimitRule;
+
 // ============ 凭据状态 ============
 
 /// 所有凭据状态响应
@@ -56,6 +58,16 @@ pub struct CredentialStatusItem {
     /// 禁用原因
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled_reason: Option<String>,
+    /// 凭据自身配置的限流规则
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limits: Option<Vec<RateLimitRule>>,
+    /// 当前生效的限流规则
+    pub effective_rate_limits: Vec<RateLimitRule>,
+    /// 当前是否因限流暂时不可用
+    pub rate_limited: bool,
+    /// 最早恢复可用时间（RFC3339）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_available_at: Option<String>,
 }
 
 // ============ 操作请求 ============
@@ -74,6 +86,15 @@ pub struct SetDisabledRequest {
 pub struct SetPriorityRequest {
     /// 新优先级值
     pub priority: u32,
+}
+
+/// 设置凭据级限流规则请求
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetRateLimitsRequest {
+    /// 限流规则；传空数组或 null 表示清空凭据级覆盖
+    #[serde(default)]
+    pub rate_limits: Option<Vec<RateLimitRule>>,
 }
 
 /// 添加凭据请求
@@ -122,6 +143,10 @@ pub struct AddCredentialRequest {
 
     /// 凭据级代理认证密码（可选）
     pub proxy_password: Option<String>,
+
+    /// 凭据级限流规则（可选）
+    #[serde(default)]
+    pub rate_limits: Option<Vec<RateLimitRule>>,
 }
 
 fn default_auth_method() -> String {
@@ -179,6 +204,21 @@ pub struct LoadBalancingModeResponse {
 pub struct SetLoadBalancingModeRequest {
     /// 模式（"priority" 或 "balanced"）
     pub mode: String,
+}
+
+/// 全局默认限流规则响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DefaultRateLimitsResponse {
+    pub default_rate_limits: Option<Vec<RateLimitRule>>,
+}
+
+/// 设置全局默认限流规则请求
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetDefaultRateLimitsRequest {
+    #[serde(default)]
+    pub default_rate_limits: Option<Vec<RateLimitRule>>,
 }
 
 // ============ 通用响应 ============

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -32,14 +32,26 @@ fn normalize_json_schema(schema: serde_json::Value) -> serde_json::Value {
     };
 
     // type（必须是字符串）
-    if !obj.get("type").and_then(|v| v.as_str()).is_some_and(|s| !s.is_empty()) {
-        obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
+    if !obj
+        .get("type")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty())
+    {
+        obj.insert(
+            "type".to_string(),
+            serde_json::Value::String("object".to_string()),
+        );
     }
 
     // properties（必须是 object）
     match obj.get("properties") {
         Some(serde_json::Value::Object(_)) => {}
-        _ => { obj.insert("properties".to_string(), serde_json::Value::Object(serde_json::Map::new())); }
+        _ => {
+            obj.insert(
+                "properties".to_string(),
+                serde_json::Value::Object(serde_json::Map::new()),
+            );
+        }
     }
 
     // required（必须是 string 数组）
@@ -56,7 +68,12 @@ fn normalize_json_schema(schema: serde_json::Value) -> serde_json::Value {
     // additionalProperties（允许 bool 或 object，其他按 true 处理）
     match obj.get("additionalProperties") {
         Some(serde_json::Value::Bool(_)) | Some(serde_json::Value::Object(_)) => {}
-        _ => { obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(true)); }
+        _ => {
+            obj.insert(
+                "additionalProperties".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
     }
 
     serde_json::Value::Object(obj)
@@ -320,10 +337,7 @@ pub fn convert_request(req: &MessagesRequest) -> Result<ConversionResult, Conver
         .with_history(history);
 
     if !tool_name_map.is_empty() {
-        tracing::info!(
-            "工具名称映射: {} 个超长名称已缩短",
-            tool_name_map.len()
-        );
+        tracing::info!("工具名称映射: {} 个超长名称已缩短", tool_name_map.len());
     }
 
     Ok(ConversionResult {
@@ -574,7 +588,10 @@ fn map_tool_name(name: &str, tool_name_map: &mut HashMap<String, String>) -> Str
 }
 
 /// 转换工具定义
-fn convert_tools(tools: &Option<Vec<super::types::Tool>>, tool_name_map: &mut HashMap<String, String>) -> Vec<Tool> {
+fn convert_tools(
+    tools: &Option<Vec<super::types::Tool>>,
+    tool_name_map: &mut HashMap<String, String>,
+) -> Vec<Tool> {
     let Some(tools) = tools else {
         return Vec::new();
     };
@@ -605,7 +622,9 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>, tool_name_map: &mut Ha
                 tool_specification: ToolSpecification {
                     name: map_tool_name(&t.name, tool_name_map),
                     description,
-                    input_schema: InputSchema::from_json(normalize_json_schema(serde_json::json!(t.input_schema))),
+                    input_schema: InputSchema::from_json(normalize_json_schema(serde_json::json!(
+                        t.input_schema
+                    ))),
                 },
             }
         })
@@ -648,7 +667,12 @@ fn has_thinking_tags(content: &str) -> bool {
 ///   注意：该切片与 `req.messages` 可能不同（prefill 时会截断末尾的 assistant 消息），
 ///   调用方应始终使用此参数而非 `req.messages`。
 /// * `model_id` - 已映射的 Kiro 模型 ID
-fn build_history(req: &MessagesRequest, messages: &[super::types::Message], model_id: &str, tool_name_map: &mut HashMap<String, String>) -> Result<Vec<Message>, ConversionError> {
+fn build_history(
+    req: &MessagesRequest,
+    messages: &[super::types::Message],
+    model_id: &str,
+    tool_name_map: &mut HashMap<String, String>,
+) -> Result<Vec<Message>, ConversionError> {
     let mut history = Vec::new();
 
     // 生成thinking前缀（如果需要）
@@ -812,7 +836,8 @@ fn convert_assistant_message(
                             if let (Some(id), Some(name)) = (block.id, block.name) {
                                 let input = block.input.unwrap_or(serde_json::json!({}));
                                 let mapped_name = map_tool_name(&name, tool_name_map);
-                                tool_uses.push(ToolUseEntry::new(id, mapped_name).with_input(input));
+                                tool_uses
+                                    .push(ToolUseEntry::new(id, mapped_name).with_input(input));
                             }
                         }
                         _ => {}
@@ -1021,13 +1046,18 @@ mod tests {
 
     #[test]
     fn test_shorten_tool_name_deterministic() {
-        let long_name = "mcp__some_very_long_server_name__some_very_long_tool_name_that_exceeds_limit";
+        let long_name =
+            "mcp__some_very_long_server_name__some_very_long_tool_name_that_exceeds_limit";
         assert!(long_name.len() > TOOL_NAME_MAX_LEN);
 
         let short1 = shorten_tool_name(long_name);
         let short2 = shorten_tool_name(long_name);
         assert_eq!(short1, short2, "相同输入应产生相同的短名称");
-        assert!(short1.len() <= TOOL_NAME_MAX_LEN, "短名称长度应 <= 63，实际 {}", short1.len());
+        assert!(
+            short1.len() <= TOOL_NAME_MAX_LEN,
+            "短名称长度应 <= 63，实际 {}",
+            short1.len()
+        );
     }
 
     #[test]
@@ -1060,7 +1090,8 @@ mod tests {
     fn test_tool_name_mapping_in_convert_request() {
         use super::super::types::{Message as AnthropicMessage, Tool as AnthropicTool};
 
-        let long_tool_name = "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
+        let long_tool_name =
+            "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
         assert!(long_tool_name.len() > TOOL_NAME_MAX_LEN);
 
         let mut schema = std::collections::HashMap::new();
@@ -1070,12 +1101,10 @@ mod tests {
         let req = MessagesRequest {
             model: "claude-sonnet-4".to_string(),
             max_tokens: 1024,
-            messages: vec![
-                AnthropicMessage {
-                    role: "user".to_string(),
-                    content: serde_json::json!("test"),
-                },
-            ],
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: serde_json::json!("test"),
+            }],
             system: None,
             stream: false,
             tools: Some(vec![AnthropicTool {
@@ -1102,8 +1131,12 @@ mod tests {
         assert!(short.len() <= TOOL_NAME_MAX_LEN);
 
         // Kiro 请求中的工具名应该是短名称
-        let tools = &result.conversation_state.current_message.user_input_message
-            .user_input_message_context.tools;
+        let tools = &result
+            .conversation_state
+            .current_message
+            .user_input_message
+            .user_input_message_context
+            .tools;
         assert_eq!(tools[0].tool_specification.name, *short);
     }
 
@@ -1111,7 +1144,8 @@ mod tests {
     fn test_tool_name_mapping_in_history() {
         use super::super::types::{Message as AnthropicMessage, Tool as AnthropicTool};
 
-        let long_tool_name = "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
+        let long_tool_name =
+            "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
 
         let mut schema = std::collections::HashMap::new();
         schema.insert("type".to_string(), serde_json::json!("object"));
@@ -1706,9 +1740,15 @@ mod tests {
 
         let content = &result.assistant_response_message.content;
         assert!(content.contains("<thinking>"), "应包含 thinking 标签");
-        assert!(content.contains("Let me read that file"), "应包含第二条消息的 text 内容");
+        assert!(
+            content.contains("Let me read that file"),
+            "应包含第二条消息的 text 内容"
+        );
 
-        let tool_uses = result.assistant_response_message.tool_uses.expect("应有 tool_uses");
+        let tool_uses = result
+            .assistant_response_message
+            .tool_uses
+            .expect("应有 tool_uses");
         assert_eq!(tool_uses.len(), 1);
         assert_eq!(tool_uses[0].tool_use_id, "toolu_01ABC");
     }
@@ -1758,7 +1798,11 @@ mod tests {
         };
 
         let result = convert_request(&req);
-        assert!(result.is_ok(), "连续 assistant 消息场景不应报错: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "连续 assistant 消息场景不应报错: {:?}",
+            result.err()
+        );
 
         let state = result.unwrap().conversation_state;
         let mut found_tool_use = false;

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -2,11 +2,11 @@
 
 use std::convert::Infallible;
 
-use anyhow::Error;
 use crate::kiro::model::events::Event;
 use crate::kiro::model::requests::kiro::KiroRequest;
 use crate::kiro::parser::decoder::EventStreamDecoder;
 use crate::token;
+use anyhow::Error;
 use axum::{
     Json as JsonExtractor,
     body::Body,
@@ -24,7 +24,10 @@ use uuid::Uuid;
 use super::converter::{ConversionError, convert_request};
 use super::middleware::AppState;
 use super::stream::{BufferedStreamContext, SseEvent, StreamContext};
-use super::types::{CountTokensRequest, CountTokensResponse, ErrorResponse, MessagesRequest, Model, ModelsResponse, OutputConfig, Thinking};
+use super::types::{
+    CountTokensRequest, CountTokensResponse, ErrorResponse, MessagesRequest, Model, ModelsResponse,
+    OutputConfig, Thinking,
+};
 use super::websearch;
 
 /// 将 KiroProvider 错误映射为 HTTP 响应
@@ -295,7 +298,15 @@ pub async fn post_messages(
     } else {
         // 非流式响应：仅在配置开启时提取 thinking 块
         let extract_thinking = state.extract_thinking && thinking_enabled;
-        handle_non_stream_request(provider, &request_body, &payload.model, input_tokens, extract_thinking, tool_name_map).await
+        handle_non_stream_request(
+            provider,
+            &request_body,
+            &payload.model,
+            input_tokens,
+            extract_thinking,
+            tool_name_map,
+        )
+        .await
     }
 }
 
@@ -315,7 +326,8 @@ async fn handle_stream_request(
     };
 
     // 创建流处理上下文
-    let mut ctx = StreamContext::new_with_thinking(model, input_tokens, thinking_enabled, tool_name_map);
+    let mut ctx =
+        StreamContext::new_with_thinking(model, input_tokens, thinking_enabled, tool_name_map);
 
     // 生成初始事件
     let initial_events = ctx.generate_initial_events();
@@ -505,14 +517,14 @@ async fn handle_non_stream_request(
                                 let input: serde_json::Value = if buffer.is_empty() {
                                     serde_json::json!({})
                                 } else {
-                                    serde_json::from_str(buffer)
-                                        .unwrap_or_else(|e| {
-                                            tracing::warn!(
-                                                "工具输入 JSON 解析失败: {}, tool_use_id: {}",
-                                                e, tool_use.tool_use_id
-                                            );
-                                            serde_json::json!({})
-                                        })
+                                    serde_json::from_str(buffer).unwrap_or_else(|e| {
+                                        tracing::warn!(
+                                            "工具输入 JSON 解析失败: {}, tool_use_id: {}",
+                                            e,
+                                            tool_use.tool_use_id
+                                        );
+                                        serde_json::json!({})
+                                    })
                                 };
 
                                 let original_name = tool_name_map
@@ -531,10 +543,9 @@ async fn handle_non_stream_request(
                         Event::ContextUsage(context_usage) => {
                             // 从上下文使用百分比计算实际的 input_tokens
                             let window_size = get_context_window_size(model);
-                            let actual_input_tokens = (context_usage.context_usage_percentage
-                                * (window_size as f64)
-                                / 100.0)
-                                as i32;
+                            let actual_input_tokens =
+                                (context_usage.context_usage_percentage * (window_size as f64)
+                                    / 100.0) as i32;
                             context_input_tokens = Some(actual_input_tokens);
                             // 上下文使用量达到 100% 时，设置 stop_reason 为 model_context_window_exceeded
                             if context_usage.context_usage_percentage >= 100.0 {
@@ -631,14 +642,10 @@ fn override_thinking_from_model_name(payload: &mut MessagesRequest) {
         return;
     }
 
-    let is_opus_4_6 =
-        model_lower.contains("opus") && (model_lower.contains("4-6") || model_lower.contains("4.6"));
+    let is_opus_4_6 = model_lower.contains("opus")
+        && (model_lower.contains("4-6") || model_lower.contains("4.6"));
 
-    let thinking_type = if is_opus_4_6 {
-        "adaptive"
-    } else {
-        "enabled"
-    };
+    let thinking_type = if is_opus_4_6 { "adaptive" } else { "enabled" };
 
     tracing::info!(
         model = %payload.model,
@@ -650,7 +657,7 @@ fn override_thinking_from_model_name(payload: &mut MessagesRequest) {
         thinking_type: thinking_type.to_string(),
         budget_tokens: 20000,
     });
-    
+
     if is_opus_4_6 {
         payload.output_config = Some(OutputConfig {
             effort: "high".to_string(),
@@ -808,7 +815,15 @@ pub async fn post_messages_cc(
     } else {
         // 非流式响应：仅在配置开启时提取 thinking 块
         let extract_thinking = state.extract_thinking && thinking_enabled;
-        handle_non_stream_request(provider, &request_body, &payload.model, input_tokens, extract_thinking, tool_name_map).await
+        handle_non_stream_request(
+            provider,
+            &request_body,
+            &payload.model,
+            input_tokens,
+            extract_thinking,
+            tool_name_map,
+        )
+        .await
     }
 }
 
@@ -831,7 +846,12 @@ async fn handle_stream_request_buffered(
     };
 
     // 创建缓冲流处理上下文
-    let ctx = BufferedStreamContext::new(model, estimated_input_tokens, thinking_enabled, tool_name_map);
+    let ctx = BufferedStreamContext::new(
+        model,
+        estimated_input_tokens,
+        thinking_enabled,
+        tool_name_map,
+    );
 
     // 创建缓冲 SSE 流
     let stream = create_buffered_sse_stream(response, ctx);

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -189,27 +189,21 @@ pub(crate) fn extract_thinking_from_complete_text(text: &str) -> (Option<String>
     let after_open = &text[start_pos + "<thinking>".len()..];
 
     // 查找结束标签：优先匹配带 \n\n 后缀的，退而使用末尾匹配
-    let (thinking_raw, text_after) =
-        if let Some(end_pos) = find_real_thinking_end_tag(after_open) {
-            (
-                &after_open[..end_pos],
-                &after_open[end_pos + "</thinking>\n\n".len()..],
-            )
-        } else if let Some(end_pos) = find_real_thinking_end_tag_at_buffer_end(after_open) {
-            let after_tag = end_pos + "</thinking>".len();
-            (
-                &after_open[..end_pos],
-                after_open[after_tag..].trim_start(),
-            )
-        } else {
-            // 找不到有效的结束标签，不做提取
-            return (None, text.to_string());
-        };
+    let (thinking_raw, text_after) = if let Some(end_pos) = find_real_thinking_end_tag(after_open) {
+        (
+            &after_open[..end_pos],
+            &after_open[end_pos + "</thinking>\n\n".len()..],
+        )
+    } else if let Some(end_pos) = find_real_thinking_end_tag_at_buffer_end(after_open) {
+        let after_tag = end_pos + "</thinking>".len();
+        (&after_open[..end_pos], after_open[after_tag..].trim_start())
+    } else {
+        // 找不到有效的结束标签，不做提取
+        return (None, text.to_string());
+    };
 
     // 剥离开头的换行符（与流式处理一致：模型输出 <thinking>\n）
-    let thinking_content = thinking_raw
-        .strip_prefix('\n')
-        .unwrap_or(thinking_raw);
+    let thinking_content = thinking_raw.strip_prefix('\n').unwrap_or(thinking_raw);
 
     // 组装剩余文本：跳过纯空白的 before 部分
     let mut remaining = String::new();
@@ -638,9 +632,8 @@ impl StreamContext {
             Event::ContextUsage(context_usage) => {
                 // 从上下文使用百分比计算实际的 input_tokens
                 let window_size = get_context_window_size(&self.model);
-                let actual_input_tokens = (context_usage.context_usage_percentage
-                    * (window_size as f64)
-                    / 100.0) as i32;
+                let actual_input_tokens =
+                    (context_usage.context_usage_percentage * (window_size as f64) / 100.0) as i32;
                 self.context_input_tokens = Some(actual_input_tokens);
                 // 上下文使用量达到 100% 时，设置 stop_reason 为 model_context_window_exceeded
                 if context_usage.context_usage_percentage >= 100.0 {
@@ -1158,8 +1151,12 @@ impl BufferedStreamContext {
         thinking_enabled: bool,
         tool_name_map: HashMap<String, String>,
     ) -> Self {
-        let inner =
-            StreamContext::new_with_thinking(model, estimated_input_tokens, thinking_enabled, tool_name_map);
+        let inner = StreamContext::new_with_thinking(
+            model,
+            estimated_input_tokens,
+            thinking_enabled,
+            tool_name_map,
+        );
         Self {
             inner,
             event_buffer: Vec::new(),
@@ -1297,7 +1294,10 @@ mod tests {
         use crate::kiro::model::events::ToolUseEvent;
 
         let mut map = HashMap::new();
-        map.insert("short_abc12345".to_string(), "mcp__very_long_original_tool_name".to_string());
+        map.insert(
+            "short_abc12345".to_string(),
+            "mcp__very_long_original_tool_name".to_string(),
+        );
 
         let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, map);
         let _ = ctx.generate_initial_events();
@@ -1313,10 +1313,12 @@ mod tests {
         let events = ctx.process_kiro_event(&tool_event);
 
         // content_block_start 中的 name 应该是原始长名称
-        let start_event = events.iter().find(|e| e.event == "content_block_start").unwrap();
+        let start_event = events
+            .iter()
+            .find(|e| e.event == "content_block_start")
+            .unwrap();
         assert_eq!(
-            start_event.data["content_block"]["name"],
-            "mcp__very_long_original_tool_name",
+            start_event.data["content_block"]["name"], "mcp__very_long_original_tool_name",
             "应还原为原始工具名称"
         );
     }
@@ -1738,7 +1740,12 @@ mod tests {
 
         let full_thinking: String = thinking_deltas
             .iter()
-            .filter(|e| !e.data["delta"]["thinking"].as_str().unwrap_or("").is_empty())
+            .filter(|e| {
+                !e.data["delta"]["thinking"]
+                    .as_str()
+                    .unwrap_or("")
+                    .is_empty()
+            })
             .map(|e| e.data["delta"]["thinking"].as_str().unwrap_or(""))
             .collect();
 
@@ -1751,14 +1758,11 @@ mod tests {
         let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new());
         let _initial_events = ctx.generate_initial_events();
 
-        let events =
-            ctx.process_assistant_response("<thinking>\nabc</thinking>\n\n你好");
+        let events = ctx.process_assistant_response("<thinking>\nabc</thinking>\n\n你好");
 
         let text_deltas: Vec<_> = events
             .iter()
-            .filter(|e| {
-                e.event == "content_block_delta" && e.data["delta"]["type"] == "text_delta"
-            })
+            .filter(|e| e.event == "content_block_delta" && e.data["delta"]["type"] == "text_delta")
             .collect();
 
         let full_text: String = text_deltas
@@ -1790,9 +1794,7 @@ mod tests {
     fn collect_text_content(events: &[SseEvent]) -> String {
         events
             .iter()
-            .filter(|e| {
-                e.event == "content_block_delta" && e.data["delta"]["type"] == "text_delta"
-            })
+            .filter(|e| e.event == "content_block_delta" && e.data["delta"]["type"] == "text_delta")
             .map(|e| e.data["delta"]["text"].as_str().unwrap_or(""))
             .collect()
     }
@@ -1811,7 +1813,11 @@ mod tests {
         all.extend(ctx.generate_final_events());
 
         let thinking = collect_thinking_content(&all);
-        assert_eq!(thinking, "abc", "thinking should be 'abc', got: {:?}", thinking);
+        assert_eq!(
+            thinking, "abc",
+            "thinking should be 'abc', got: {:?}",
+            thinking
+        );
 
         let text = collect_text_content(&all);
         assert_eq!(text, "你好", "text should be '你好', got: {:?}", text);
@@ -1829,7 +1835,11 @@ mod tests {
         all.extend(ctx.generate_final_events());
 
         let thinking = collect_thinking_content(&all);
-        assert_eq!(thinking, "abc", "thinking should be 'abc', got: {:?}", thinking);
+        assert_eq!(
+            thinking, "abc",
+            "thinking should be 'abc', got: {:?}",
+            thinking
+        );
 
         let text = collect_text_content(&all);
         assert_eq!(text, "你好", "text should be '你好', got: {:?}", text);
@@ -1849,7 +1859,11 @@ mod tests {
         all.extend(ctx.generate_final_events());
 
         let thinking = collect_thinking_content(&all);
-        assert_eq!(thinking, "abc", "thinking should be 'abc', got: {:?}", thinking);
+        assert_eq!(
+            thinking, "abc",
+            "thinking should be 'abc', got: {:?}",
+            thinking
+        );
 
         let text = collect_text_content(&all);
         assert_eq!(text, "text", "text should be 'text', got: {:?}", text);
@@ -1878,7 +1892,11 @@ mod tests {
         all.extend(ctx.generate_final_events());
 
         let thinking = collect_thinking_content(&all);
-        assert_eq!(thinking, "hello", "thinking should be 'hello', got: {:?}", thinking);
+        assert_eq!(
+            thinking, "hello",
+            "thinking should be 'hello', got: {:?}",
+            thinking
+        );
 
         let text = collect_text_content(&all);
         assert_eq!(text, "world", "text should be 'world', got: {:?}", text);
@@ -1968,12 +1986,14 @@ mod tests {
 
         let mut all_events = Vec::new();
         all_events.extend(ctx.process_assistant_response("<thinking>\nabc</thinking>"));
-        all_events.extend(ctx.process_tool_use(&crate::kiro::model::events::ToolUseEvent {
-            name: "test_tool".to_string(),
-            tool_use_id: "tool_1".to_string(),
-            input: "{}".to_string(),
-            stop: true,
-        }));
+        all_events.extend(
+            ctx.process_tool_use(&crate::kiro::model::events::ToolUseEvent {
+                name: "test_tool".to_string(),
+                tool_use_id: "tool_1".to_string(),
+                input: "{}".to_string(),
+                stop: true,
+            }),
+        );
         all_events.extend(ctx.generate_final_events());
 
         let message_delta = all_events

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -65,6 +65,10 @@ pub fn build_client(
 
         builder = builder.proxy(proxy);
         tracing::debug!("HTTP Client 使用代理: {}", proxy_config.url);
+    } else {
+        // 未显式配置代理时，明确禁用系统代理探测。
+        // 这样可避免不同运行环境下隐式继承系统/环境代理，语义也更符合本项目配置预期。
+        builder = builder.no_proxy();
     }
 
     Ok(builder.build()?)

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 
 use crate::http_client::ProxyConfig;
 use crate::model::config::Config;
-use crate::model::rate_limit::{RateLimitRule, effective_rate_limit_rules, validate_rate_limit_rules};
+use crate::model::rate_limit::{
+    RateLimitRule, effective_rate_limit_rules, validate_rate_limit_rules,
+};
 
 /// Kiro OAuth 凭证
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -269,10 +271,7 @@ impl KiroCredentials {
     }
 
     pub fn validate(&self, source: &str) -> anyhow::Result<()> {
-        validate_rate_limit_rules(
-            self.rate_limits.as_deref(),
-            &format!("{source}.rateLimits"),
-        )
+        validate_rate_limit_rules(self.rate_limits.as_deref(), &format!("{source}.rateLimits"))
     }
 }
 

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use crate::http_client::ProxyConfig;
 use crate::model::config::Config;
+use crate::model::rate_limit::{RateLimitRule, effective_rate_limit_rules, validate_rate_limit_rules};
 
 /// Kiro OAuth 凭证
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -96,6 +97,11 @@ pub struct KiroCredentials {
     /// 凭据是否被禁用（默认为 false）
     #[serde(default)]
     pub disabled: bool,
+
+    /// 凭据级限流规则（可选）
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limits: Option<Vec<RateLimitRule>>,
 }
 
 /// 判断是否为零（用于跳过序列化）
@@ -147,6 +153,14 @@ impl CredentialsConfig {
         }
 
         let config = serde_json::from_str(&content)?;
+        match &config {
+            CredentialsConfig::Single(cred) => cred.validate("credentials")?,
+            CredentialsConfig::Multiple(creds) => {
+                for (idx, cred) in creds.iter().enumerate() {
+                    cred.validate(&format!("credentials[{idx}]"))?;
+                }
+            }
+        }
         Ok(config)
     }
 
@@ -245,6 +259,21 @@ impl KiroCredentials {
             None => true,
         }
     }
+
+    pub fn effective_rate_limits(&self, config: &Config) -> Vec<RateLimitRule> {
+        effective_rate_limit_rules(
+            config.default_rate_limits.as_deref(),
+            self.rate_limits.as_deref(),
+        )
+        .unwrap_or_default()
+    }
+
+    pub fn validate(&self, source: &str) -> anyhow::Result<()> {
+        validate_rate_limit_rules(
+            self.rate_limits.as_deref(),
+            &format!("{source}.rateLimits"),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -314,6 +343,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            rate_limits: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -431,6 +461,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            rate_limits: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -461,6 +492,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            rate_limits: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -573,6 +605,7 @@ mod tests {
             proxy_username: None,
             proxy_password: None,
             disabled: false,
+            rate_limits: None,
         };
 
         let json = original.to_pretty_json().unwrap();

--- a/src/kiro/parser/decoder.rs
+++ b/src/kiro/parser/decoder.rs
@@ -289,7 +289,6 @@ impl EventStreamDecoder {
             }
         }
     }
-
 }
 
 /// 解码迭代器

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -44,8 +44,8 @@ impl KiroProvider {
     pub fn with_proxy(token_manager: Arc<MultiTokenManager>, proxy: Option<ProxyConfig>) -> Self {
         let tls_backend = token_manager.config().tls_backend;
         // 预热：构建全局代理对应的 Client
-        let initial_client = build_client(proxy.as_ref(), 720, tls_backend)
-            .expect("创建 HTTP 客户端失败");
+        let initial_client =
+            build_client(proxy.as_ref(), 720, tls_backend).expect("创建 HTTP 客户端失败");
         let mut cache = HashMap::new();
         cache.insert(proxy.clone(), initial_client);
 
@@ -192,7 +192,8 @@ impl KiroProvider {
             };
 
             let config = self.token_manager.config();
-            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config) {
+            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config)
+            {
                 Some(id) => id,
                 None => {
                     last_error = Some(anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"));
@@ -201,7 +202,10 @@ impl KiroProvider {
             };
 
             let url = self.mcp_url_for(&ctx.credentials);
-            let x_amz_user_agent = format!("aws-sdk-js/1.0.34 KiroIDE-{}-{}", config.kiro_version, machine_id);
+            let x_amz_user_agent = format!(
+                "aws-sdk-js/1.0.34 KiroIDE-{}-{}",
+                config.kiro_version, machine_id
+            );
             let user_agent = format!(
                 "aws-sdk-js/1.0.34 ua/2.1 os/{} lang/js md/nodejs#{} api/codewhispererstreaming#1.0.34 m/E KiroIDE-{}-{}",
                 config.system_version, config.node_version, config.kiro_version, machine_id
@@ -278,7 +282,12 @@ impl KiroProvider {
                 if Self::is_bearer_token_invalid(&body) && !force_refreshed.contains(&ctx.id) {
                     force_refreshed.insert(ctx.id);
                     tracing::info!("凭据 #{} token 疑似被上游失效，尝试强制刷新", ctx.id);
-                    if self.token_manager.force_refresh_token_for(ctx.id).await.is_ok() {
+                    if self
+                        .token_manager
+                        .force_refresh_token_for(ctx.id)
+                        .await
+                        .is_ok()
+                    {
                         tracing::info!("凭据 #{} token 强制刷新成功，重试请求", ctx.id);
                         continue;
                     }
@@ -357,7 +366,8 @@ impl KiroProvider {
             };
 
             let config = self.token_manager.config();
-            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config) {
+            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config)
+            {
                 Some(id) => id,
                 None => {
                     last_error = Some(anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"));
@@ -366,7 +376,10 @@ impl KiroProvider {
             };
 
             let url = self.base_url_for(&ctx.credentials);
-            let x_amz_user_agent = format!("aws-sdk-js/1.0.34 KiroIDE-{}-{}", config.kiro_version, machine_id);
+            let x_amz_user_agent = format!(
+                "aws-sdk-js/1.0.34 KiroIDE-{}-{}",
+                config.kiro_version, machine_id
+            );
             let user_agent = format!(
                 "aws-sdk-js/1.0.34 ua/2.1 os/{} lang/js md/nodejs#{} api/codewhispererstreaming#1.0.34 m/E KiroIDE-{}-{}",
                 config.system_version, config.node_version, config.kiro_version, machine_id
@@ -470,7 +483,12 @@ impl KiroProvider {
                 if Self::is_bearer_token_invalid(&body) && !force_refreshed.contains(&ctx.id) {
                     force_refreshed.insert(ctx.id);
                     tracing::info!("凭据 #{} token 疑似被上游失效，尝试强制刷新", ctx.id);
-                    if self.token_manager.force_refresh_token_for(ctx.id).await.is_ok() {
+                    if self
+                        .token_manager
+                        .force_refresh_token_for(ctx.id)
+                        .await
+                        .is_ok()
+                    {
                         tracing::info!("凭据 #{} token 强制刷新成功，重试请求", ctx.id);
                         continue;
                     }

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -71,25 +71,28 @@ impl KiroProvider {
 
     /// 获取凭据级 API 基础 URL
     fn base_url_for(&self, credentials: &KiroCredentials) -> String {
+        let config = self.token_manager.config();
         format!(
             "https://q.{}.amazonaws.com/generateAssistantResponse",
-            credentials.effective_api_region(self.token_manager.config())
+            credentials.effective_api_region(&config)
         )
     }
 
     /// 获取凭据级 MCP API URL
     fn mcp_url_for(&self, credentials: &KiroCredentials) -> String {
+        let config = self.token_manager.config();
         format!(
             "https://q.{}.amazonaws.com/mcp",
-            credentials.effective_api_region(self.token_manager.config())
+            credentials.effective_api_region(&config)
         )
     }
 
     /// 获取凭据级 API 基础域名
     fn base_domain_for(&self, credentials: &KiroCredentials) -> String {
+        let config = self.token_manager.config();
         format!(
             "q.{}.amazonaws.com",
-            credentials.effective_api_region(self.token_manager.config())
+            credentials.effective_api_region(&config)
         )
     }
 
@@ -189,7 +192,7 @@ impl KiroProvider {
             };
 
             let config = self.token_manager.config();
-            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, config) {
+            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config) {
                 Some(id) => id,
                 None => {
                     last_error = Some(anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"));
@@ -354,7 +357,7 @@ impl KiroProvider {
             };
 
             let config = self.token_manager.config();
-            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, config) {
+            let machine_id = match machine_id::generate_from_credentials(&ctx.credentials, &config) {
                 Some(id) => id,
                 None => {
                     last_error = Some(anyhow::anyhow!("无法生成 machine_id，请检查凭证配置"));

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -340,10 +340,7 @@ pub(crate) async fn get_usage_limits(
         "aws-sdk-js/1.0.0 ua/2.1 os/{} lang/js md/nodejs#{} api/codewhispererruntime#1.0.0 m/N,E KiroIDE-{}-{}",
         os_name, node_version, kiro_version, machine_id
     );
-    let amz_user_agent = format!(
-        "aws-sdk-js/1.0.0 KiroIDE-{}-{}",
-        kiro_version, machine_id
-    );
+    let amz_user_agent = format!("aws-sdk-js/1.0.0 KiroIDE-{}-{}", kiro_version, machine_id);
 
     let client = build_client(proxy, 60, config.tls_backend)?;
 
@@ -435,6 +432,15 @@ enum RateLimitAvailability {
     LimitedUntil(Instant),
 }
 
+#[derive(Debug, Clone)]
+struct RuleRuntimeState {
+    window: String,
+    window_seconds: u64,
+    max_requests: u32,
+    remaining_requests: u32,
+    limited_until: Option<Instant>,
+}
+
 enum CredentialSelection {
     Ready(u64, KiroCredentials),
     WaitUntil(Instant),
@@ -491,6 +497,24 @@ pub struct CredentialEntrySnapshot {
     /// 最早恢复可用时间（RFC3339 格式）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_available_at: Option<String>,
+    /// 当前最紧张的限流窗口摘要
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_summary: Option<RateLimitSummarySnapshot>,
+    /// 当前最紧张的前两条限流窗口摘要
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub rate_limit_summaries: Vec<RateLimitSummarySnapshot>,
+}
+
+/// 限流摘要快照
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitSummarySnapshot {
+    /// 当前最紧张的时间窗口
+    pub window: String,
+    /// 该窗口允许的最大请求数
+    pub max_requests: u32,
+    /// 该窗口剩余可用请求数
+    pub remaining_requests: u32,
 }
 
 /// 凭据管理器状态快照
@@ -698,7 +722,11 @@ impl MultiTokenManager {
             return RateLimitAvailability::Ready;
         }
 
-        let max_window = rules.iter().map(|rule| rule.window_seconds).max().unwrap_or(0);
+        let max_window = rules
+            .iter()
+            .map(|rule| rule.window_seconds)
+            .max()
+            .unwrap_or(0);
         let max_window_duration = StdDuration::from_secs(max_window);
         while let Some(front) = state.request_timestamps.front() {
             if now.duration_since(*front) >= max_window_duration {
@@ -736,6 +764,82 @@ impl MultiTokenManager {
             .unwrap_or(RateLimitAvailability::Ready)
     }
 
+    fn collect_rule_runtime_states(
+        state: &CredentialRateLimitState,
+        rules: &[ResolvedRateLimitRule],
+        now: Instant,
+    ) -> Vec<RuleRuntimeState> {
+        rules
+            .iter()
+            .map(|rule| {
+                let window_duration = StdDuration::from_secs(rule.window_seconds);
+                let in_window: Vec<_> = state
+                    .request_timestamps
+                    .iter()
+                    .copied()
+                    .filter(|ts| ts.checked_add(window_duration).is_some_and(|end| end > now))
+                    .collect();
+
+                let count = in_window.len();
+                let limited_until = if count >= rule.max_requests as usize {
+                    let release_index = count - rule.max_requests as usize;
+                    in_window.get(release_index).map(|ts| *ts + window_duration)
+                } else {
+                    None
+                };
+
+                RuleRuntimeState {
+                    window: rule.window.clone(),
+                    window_seconds: rule.window_seconds,
+                    max_requests: rule.max_requests,
+                    remaining_requests: rule.max_requests.saturating_sub(count as u32),
+                    limited_until,
+                }
+            })
+            .collect()
+    }
+
+    fn summarize_rate_limits(
+        state: &CredentialRateLimitState,
+        rules: &[ResolvedRateLimitRule],
+        now: Instant,
+    ) -> Option<RateLimitSummarySnapshot> {
+        Self::summarize_rate_limits_top_n(state, rules, now, 1)
+            .into_iter()
+            .next()
+    }
+
+    fn summarize_rate_limits_top_n(
+        state: &CredentialRateLimitState,
+        rules: &[ResolvedRateLimitRule],
+        now: Instant,
+        limit: usize,
+    ) -> Vec<RateLimitSummarySnapshot> {
+        let mut statuses = Self::collect_rule_runtime_states(state, rules, now);
+        statuses.sort_by(|left, right| {
+            left.remaining_requests
+                .cmp(&right.remaining_requests)
+                .then_with(|| match (left.limited_until, right.limited_until) {
+                    (Some(left_until), Some(right_until)) => left_until.cmp(&right_until),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => std::cmp::Ordering::Equal,
+                })
+                .then_with(|| left.window_seconds.cmp(&right.window_seconds))
+                .then_with(|| left.max_requests.cmp(&right.max_requests))
+        });
+
+        statuses
+            .into_iter()
+            .take(limit)
+            .map(|status| RateLimitSummarySnapshot {
+                window: status.window,
+                max_requests: status.max_requests,
+                remaining_requests: status.remaining_requests,
+            })
+            .collect()
+    }
+
     fn reserve_rate_limit_slot(&self, id: u64, now: Instant) {
         let config = self.config();
         let mut entries = self.entries.lock();
@@ -746,7 +850,11 @@ impl MultiTokenManager {
         }
     }
 
-    fn instant_to_rfc3339(instant: Instant, now: Instant, wall_now: DateTime<Utc>) -> Option<String> {
+    fn instant_to_rfc3339(
+        instant: Instant,
+        now: Instant,
+        wall_now: DateTime<Utc>,
+    ) -> Option<String> {
         let wait = instant.checked_duration_since(now)?;
         let chrono_wait = Duration::from_std(wait).ok()?;
         Some((wall_now + chrono_wait).to_rfc3339())
@@ -923,7 +1031,11 @@ impl MultiTokenManager {
                     } else {
                         let entries = self.entries.lock();
                         let available = entries.iter().filter(|e| !e.disabled).count();
-                        anyhow::bail!("所有凭据均已禁用或不支持当前模型（{}/{}）", available, total);
+                        anyhow::bail!(
+                            "所有凭据均已禁用或不支持当前模型（{}/{}）",
+                            available,
+                            total
+                        );
                     }
                 }
             };
@@ -936,14 +1048,13 @@ impl MultiTokenManager {
                 }
                 Err(e) => {
                     // refreshToken 永久失效 → 立即禁用，不累计重试
-                    let has_available =
-                        if e.downcast_ref::<RefreshTokenInvalidError>().is_some() {
-                            tracing::warn!("凭据 #{} refreshToken 永久失效: {}", id, e);
-                            self.report_refresh_token_invalid(id)
-                        } else {
-                            tracing::warn!("凭据 #{} Token 刷新失败: {}", id, e);
-                            self.report_refresh_failure(id)
-                        };
+                    let has_available = if e.downcast_ref::<RefreshTokenInvalidError>().is_some() {
+                        tracing::warn!("凭据 #{} refreshToken 永久失效: {}", id, e);
+                        self.report_refresh_token_invalid(id)
+                    } else {
+                        tracing::warn!("凭据 #{} Token 刷新失败: {}", id, e);
+                        self.report_refresh_failure(id)
+                    };
                     attempt_count += 1;
                     if !has_available {
                         anyhow::bail!("所有凭据均已禁用（0/{}）", total);
@@ -1508,6 +1619,10 @@ impl MultiTokenManager {
                             Self::instant_to_rfc3339(next, now, wall_now)
                         }
                     };
+                    let rate_limit_summary =
+                        Self::summarize_rate_limits(&e.rate_limit_state, &resolved, now);
+                    let rate_limit_summaries =
+                        Self::summarize_rate_limits_top_n(&e.rate_limit_state, &resolved, now, 2);
 
                     CredentialEntrySnapshot {
                         id: e.id,
@@ -1531,17 +1646,22 @@ impl MultiTokenManager {
                         has_proxy: e.credentials.proxy_url.is_some(),
                         proxy_url: e.credentials.proxy_url.clone(),
                         refresh_failure_count: e.refresh_failure_count,
-                        disabled_reason: e.disabled_reason.map(|r| match r {
-                            DisabledReason::Manual => "Manual",
-                            DisabledReason::TooManyFailures => "TooManyFailures",
-                            DisabledReason::TooManyRefreshFailures => "TooManyRefreshFailures",
-                            DisabledReason::QuotaExceeded => "QuotaExceeded",
-                            DisabledReason::InvalidRefreshToken => "InvalidRefreshToken",
-                        }.to_string()),
+                        disabled_reason: e.disabled_reason.map(|r| {
+                            match r {
+                                DisabledReason::Manual => "Manual",
+                                DisabledReason::TooManyFailures => "TooManyFailures",
+                                DisabledReason::TooManyRefreshFailures => "TooManyRefreshFailures",
+                                DisabledReason::QuotaExceeded => "QuotaExceeded",
+                                DisabledReason::InvalidRefreshToken => "InvalidRefreshToken",
+                            }
+                            .to_string()
+                        }),
                         rate_limits: e.credentials.rate_limits.clone(),
                         effective_rate_limits,
                         rate_limited: next_available_at.is_some(),
                         next_available_at,
+                        rate_limit_summary,
+                        rate_limit_summaries,
                     }
                 })
                 .collect(),
@@ -1600,7 +1720,8 @@ impl MultiTokenManager {
         id: u64,
         rate_limits: Option<Vec<RateLimitRule>>,
     ) -> anyhow::Result<()> {
-        let normalized = Self::normalize_optional_rate_limits(rate_limits, "credentials.rateLimits")?;
+        let normalized =
+            Self::normalize_optional_rate_limits(rate_limits, "credentials.rateLimits")?;
 
         {
             let mut entries = self.entries.lock();
@@ -1708,8 +1829,7 @@ impl MultiTokenManager {
                 if let Some(entry) = entries.iter_mut().find(|e| e.id == id) {
                     let old_title = entry.credentials.subscription_title.clone();
                     if old_title.as_deref() != Some(subscription_title) {
-                        entry.credentials.subscription_title =
-                            Some(subscription_title.to_string());
+                        entry.credentials.subscription_title = Some(subscription_title.to_string());
                         tracing::info!(
                             "凭据 #{} 订阅等级已更新: {:?} -> {}",
                             id,
@@ -2220,21 +2340,14 @@ mod tests {
 
     #[test]
     fn test_set_load_balancing_mode_persists_to_config_file() {
-        let config_path = std::env::temp_dir().join(format!(
-            "kiro-load-balancing-{}.json",
-            uuid::Uuid::new_v4()
-        ));
+        let config_path =
+            std::env::temp_dir().join(format!("kiro-load-balancing-{}.json", uuid::Uuid::new_v4()));
         std::fs::write(&config_path, r#"{"loadBalancingMode":"priority"}"#).unwrap();
 
         let config = Config::load(&config_path).unwrap();
-        let manager = MultiTokenManager::new(
-            config,
-            vec![KiroCredentials::default()],
-            None,
-            None,
-            false,
-        )
-        .unwrap();
+        let manager =
+            MultiTokenManager::new(config, vec![KiroCredentials::default()], None, None, false)
+                .unwrap();
 
         manager
             .set_load_balancing_mode("balanced".to_string())
@@ -2268,6 +2381,77 @@ mod tests {
         assert!(entry.next_available_at.is_some());
         assert_eq!(entry.effective_rate_limits.len(), 1);
         assert_eq!(entry.effective_rate_limits[0].window, "1m");
+        let summary = entry.rate_limit_summary.as_ref().unwrap();
+        assert_eq!(summary.window, "1m");
+        assert_eq!(summary.max_requests, 1);
+        assert_eq!(summary.remaining_requests, 0);
+    }
+
+    #[test]
+    fn test_snapshot_prefers_tightest_rate_limit_summary() {
+        let mut config = Config::default();
+        config.default_rate_limits = Some(vec![
+            RateLimitRule {
+                window: "1m".to_string(),
+                max_requests: 2,
+            },
+            RateLimitRule {
+                window: "1h".to_string(),
+                max_requests: 100,
+            },
+        ]);
+
+        let mut credential = KiroCredentials::default();
+        credential.access_token = Some("token".to_string());
+        credential.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+
+        let manager = MultiTokenManager::new(config, vec![credential], None, None, false).unwrap();
+        manager.reserve_rate_limit_slot(1, Instant::now());
+
+        let snapshot = manager.snapshot();
+        let summary = snapshot.entries[0].rate_limit_summary.as_ref().unwrap();
+        assert_eq!(summary.window, "1m");
+        assert_eq!(summary.max_requests, 2);
+        assert_eq!(summary.remaining_requests, 1);
+        let summaries = &snapshot.entries[0].rate_limit_summaries;
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].window, "1m");
+        assert_eq!(summaries[0].remaining_requests, 1);
+        assert_eq!(summaries[1].window, "1h");
+        assert_eq!(summaries[1].remaining_requests, 99);
+    }
+
+    #[test]
+    fn test_snapshot_orders_summaries_by_remaining_requests() {
+        let mut config = Config::default();
+        config.default_rate_limits = Some(vec![
+            RateLimitRule {
+                window: "5m".to_string(),
+                max_requests: 10,
+            },
+            RateLimitRule {
+                window: "1d".to_string(),
+                max_requests: 200,
+            },
+        ]);
+
+        let mut credential = KiroCredentials::default();
+        credential.access_token = Some("token".to_string());
+        credential.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+
+        let manager = MultiTokenManager::new(config, vec![credential], None, None, false).unwrap();
+
+        for _ in 0..16 {
+            manager.reserve_rate_limit_slot(1, Instant::now());
+        }
+
+        let snapshot = manager.snapshot();
+        let summaries = &snapshot.entries[0].rate_limit_summaries;
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].window, "5m");
+        assert_eq!(summaries[0].remaining_requests, 0);
+        assert_eq!(summaries[1].window, "1d");
+        assert_eq!(summaries[1].remaining_requests, 184);
     }
 
     #[tokio::test]
@@ -2326,7 +2510,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_multi_token_manager_acquire_context_balanced_retries_until_bad_credential_disabled() {
+    async fn test_multi_token_manager_acquire_context_balanced_retries_until_bad_credential_disabled()
+     {
         let mut config = Config::default();
         config.load_balancing_mode = "balanced".to_string();
 
@@ -2387,7 +2572,12 @@ mod tests {
         }
         assert_eq!(manager.available_count(), 0);
 
-        let err = manager.acquire_context(None).await.err().unwrap().to_string();
+        let err = manager
+            .acquire_context(None)
+            .await
+            .err()
+            .unwrap()
+            .to_string();
         assert!(
             err.contains("所有凭据均已禁用"),
             "错误应提示所有凭据禁用，实际: {}",
@@ -2427,7 +2617,12 @@ mod tests {
         manager.report_quota_exhausted(2);
         assert_eq!(manager.available_count(), 0);
 
-        let err = manager.acquire_context(None).await.err().unwrap().to_string();
+        let err = manager
+            .acquire_context(None)
+            .await
+            .err()
+            .unwrap()
+            .to_string();
         assert!(
             err.contains("所有凭据均已禁用"),
             "错误应提示所有凭据禁用，实际: {}",

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -5,12 +5,13 @@
 
 use anyhow::bail;
 use chrono::{DateTime, Duration, Utc};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex as TokioMutex;
+use tokio::time::{Instant as TokioInstant, sleep_until};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -24,6 +25,7 @@ use crate::kiro::model::token_refresh::{
 };
 use crate::kiro::model::usage_limits::UsageLimitsResponse;
 use crate::model::config::Config;
+use crate::model::rate_limit::{RateLimitRule, ResolvedRateLimitRule, resolve_rate_limit_rules};
 
 /// 检查 Token 是否在指定时间内过期
 pub(crate) fn is_token_expiring_within(
@@ -396,6 +398,8 @@ struct CredentialEntry {
     success_count: u64,
     /// 最后一次 API 调用时间（RFC3339 格式）
     last_used_at: Option<String>,
+    /// 运行时限流状态（仅内存）
+    rate_limit_state: CredentialRateLimitState,
 }
 
 /// 禁用原因
@@ -418,6 +422,23 @@ enum DisabledReason {
 struct StatsEntry {
     success_count: u64,
     last_used_at: Option<String>,
+}
+
+#[derive(Default)]
+struct CredentialRateLimitState {
+    request_timestamps: VecDeque<Instant>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RateLimitAvailability {
+    Ready,
+    LimitedUntil(Instant),
+}
+
+enum CredentialSelection {
+    Ready(u64, KiroCredentials),
+    WaitUntil(Instant),
+    NoneAvailable,
 }
 
 // ============================================================================
@@ -460,6 +481,16 @@ pub struct CredentialEntrySnapshot {
     /// 禁用原因
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled_reason: Option<String>,
+    /// 凭据自身声明的限流规则
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limits: Option<Vec<RateLimitRule>>,
+    /// 当前生效的限流规则
+    pub effective_rate_limits: Vec<RateLimitRule>,
+    /// 当前是否因限流不可用
+    pub rate_limited: bool,
+    /// 最早恢复可用时间（RFC3339 格式）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_available_at: Option<String>,
 }
 
 /// 凭据管理器状态快照
@@ -481,7 +512,7 @@ pub struct ManagerSnapshot {
 /// 支持多个凭据的管理，实现固定优先级 + 故障转移策略
 /// 故障统计基于 API 调用结果，而非 Token 刷新结果
 pub struct MultiTokenManager {
-    config: Config,
+    config: RwLock<Config>,
     proxy: Option<ProxyConfig>,
     /// 凭据条目列表
     entries: Mutex<Vec<CredentialEntry>>,
@@ -575,6 +606,7 @@ impl MultiTokenManager {
                     },
                     success_count: 0,
                     last_used_at: None,
+                    rate_limit_state: CredentialRateLimitState::default(),
                 }
             })
             .collect();
@@ -600,7 +632,7 @@ impl MultiTokenManager {
 
         let load_balancing_mode = config.load_balancing_mode.clone();
         let manager = Self {
-            config,
+            config: RwLock::new(config),
             proxy,
             entries: Mutex::new(entries),
             current_id: Mutex::new(initial_id),
@@ -628,8 +660,8 @@ impl MultiTokenManager {
     }
 
     /// 获取配置的引用
-    pub fn config(&self) -> &Config {
-        &self.config
+    pub fn config(&self) -> Config {
+        self.config.read().clone()
     }
 
     /// 获取凭据总数
@@ -642,58 +674,180 @@ impl MultiTokenManager {
         self.entries.lock().iter().filter(|e| !e.disabled).count()
     }
 
-    /// 根据负载均衡模式选择下一个凭据
-    ///
-    /// - priority 模式：选择优先级最高（priority 最小）的可用凭据
-    /// - balanced 模式：均衡选择可用凭据
-    ///
-    /// # 参数
-    /// - `model`: 可选的模型名称，用于过滤支持该模型的凭据（如 opus 模型需要付费订阅）
-    fn select_next_credential(&self, model: Option<&str>) -> Option<(u64, KiroCredentials)> {
-        let entries = self.entries.lock();
-
-        // 检查是否是 opus 模型
+    fn supports_model(credentials: &KiroCredentials, model: Option<&str>) -> bool {
         let is_opus = model
             .map(|m| m.to_lowercase().contains("opus"))
             .unwrap_or(false);
+        !is_opus || credentials.supports_opus()
+    }
 
-        // 过滤可用凭据
-        let available: Vec<_> = entries
-            .iter()
-            .filter(|e| {
-                if e.disabled {
-                    return false;
-                }
-                // 如果是 opus 模型，需要检查订阅等级
-                if is_opus && !e.credentials.supports_opus() {
-                    return false;
-                }
-                true
-            })
-            .collect();
+    fn effective_resolved_rate_limits(
+        credentials: &KiroCredentials,
+        config: &Config,
+    ) -> Vec<ResolvedRateLimitRule> {
+        let effective = credentials.effective_rate_limits(config);
+        resolve_rate_limit_rules(&effective, "effectiveRateLimits").unwrap_or_default()
+    }
 
-        if available.is_empty() {
-            return None;
+    fn check_rate_limit(
+        state: &mut CredentialRateLimitState,
+        rules: &[ResolvedRateLimitRule],
+        now: Instant,
+    ) -> RateLimitAvailability {
+        if rules.is_empty() {
+            return RateLimitAvailability::Ready;
         }
 
+        let max_window = rules.iter().map(|rule| rule.window_seconds).max().unwrap_or(0);
+        let max_window_duration = StdDuration::from_secs(max_window);
+        while let Some(front) = state.request_timestamps.front() {
+            if now.duration_since(*front) >= max_window_duration {
+                state.request_timestamps.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        let mut limited_until = None;
+        for rule in rules {
+            let window_duration = StdDuration::from_secs(rule.window_seconds);
+            let in_window: Vec<_> = state
+                .request_timestamps
+                .iter()
+                .copied()
+                .filter(|ts| ts.checked_add(window_duration).is_some_and(|end| end > now))
+                .collect();
+
+            let count = in_window.len();
+            if count >= rule.max_requests as usize {
+                let release_index = count - rule.max_requests as usize;
+                if let Some(ts) = in_window.get(release_index) {
+                    let available_at = *ts + window_duration;
+                    limited_until = Some(match limited_until {
+                        Some(current) if current >= available_at => current,
+                        _ => available_at,
+                    });
+                }
+            }
+        }
+
+        limited_until
+            .map(RateLimitAvailability::LimitedUntil)
+            .unwrap_or(RateLimitAvailability::Ready)
+    }
+
+    fn reserve_rate_limit_slot(&self, id: u64, now: Instant) {
+        let config = self.config();
+        let mut entries = self.entries.lock();
+        if let Some(entry) = entries.iter_mut().find(|e| e.id == id) {
+            let rules = Self::effective_resolved_rate_limits(&entry.credentials, &config);
+            let _ = Self::check_rate_limit(&mut entry.rate_limit_state, &rules, now);
+            entry.rate_limit_state.request_timestamps.push_back(now);
+        }
+    }
+
+    fn instant_to_rfc3339(instant: Instant, now: Instant, wall_now: DateTime<Utc>) -> Option<String> {
+        let wait = instant.checked_duration_since(now)?;
+        let chrono_wait = Duration::from_std(wait).ok()?;
+        Some((wall_now + chrono_wait).to_rfc3339())
+    }
+
+    fn normalize_optional_rate_limits(
+        rate_limits: Option<Vec<RateLimitRule>>,
+        source: &str,
+    ) -> anyhow::Result<Option<Vec<RateLimitRule>>> {
+        let Some(rate_limits) = rate_limits else {
+            return Ok(None);
+        };
+
+        if rate_limits.is_empty() {
+            return Ok(None);
+        }
+
+        let normalized = resolve_rate_limit_rules(&rate_limits, source)?
+            .into_iter()
+            .map(|rule| RateLimitRule {
+                window: rule.window,
+                max_requests: rule.max_requests,
+            })
+            .collect::<Vec<_>>();
+        Ok(Some(normalized))
+    }
+
+    fn select_next_credential(&self, model: Option<&str>) -> CredentialSelection {
+        let config = self.config();
         let mode = self.load_balancing_mode.lock().clone();
-        let mode = mode.as_str();
+        let now = Instant::now();
+        let mut entries = self.entries.lock();
+        let current_id_value = *self.current_id.lock();
+        let mut earliest_wait: Option<Instant> = None;
 
-        match mode {
-            "balanced" => {
-                // Least-Used 策略：选择成功次数最少的凭据
-                // 平局时按优先级排序（数字越小优先级越高）
-                let entry = available
-                    .iter()
-                    .min_by_key(|e| (e.success_count, e.credentials.priority))?;
+        if mode != "balanced" {
+            if let Some(entry) = entries
+                .iter_mut()
+                .find(|e| e.id == current_id_value && !e.disabled)
+            {
+                if Self::supports_model(&entry.credentials, model) {
+                    let rules = Self::effective_resolved_rate_limits(&entry.credentials, &config);
+                    if matches!(
+                        Self::check_rate_limit(&mut entry.rate_limit_state, &rules, now),
+                        RateLimitAvailability::Ready
+                    ) {
+                        return CredentialSelection::Ready(entry.id, entry.credentials.clone());
+                    }
+                    if let RateLimitAvailability::LimitedUntil(next) =
+                        Self::check_rate_limit(&mut entry.rate_limit_state, &rules, now)
+                    {
+                        earliest_wait = Some(match earliest_wait {
+                            Some(current) if current <= next => current,
+                            _ => next,
+                        });
+                    }
+                }
+            }
+        }
 
-                Some((entry.id, entry.credentials.clone()))
+        let mut available_indices = Vec::new();
+        for (idx, entry) in entries.iter_mut().enumerate() {
+            if entry.disabled || !Self::supports_model(&entry.credentials, model) {
+                continue;
             }
-            _ => {
-                // priority 模式（默认）：选择优先级最高的
-                let entry = available.iter().min_by_key(|e| e.credentials.priority)?;
-                Some((entry.id, entry.credentials.clone()))
+
+            let rules = Self::effective_resolved_rate_limits(&entry.credentials, &config);
+            match Self::check_rate_limit(&mut entry.rate_limit_state, &rules, now) {
+                RateLimitAvailability::Ready => available_indices.push(idx),
+                RateLimitAvailability::LimitedUntil(next) => {
+                    earliest_wait = Some(match earliest_wait {
+                        Some(current) if current <= next => current,
+                        _ => next,
+                    });
+                }
             }
+        }
+
+        if !available_indices.is_empty() {
+            let selected_index = match mode.as_str() {
+                "balanced" => available_indices
+                    .into_iter()
+                    .min_by_key(|idx| {
+                        let entry = &entries[*idx];
+                        (entry.success_count, entry.credentials.priority)
+                    })
+                    .unwrap(),
+                _ => available_indices
+                    .into_iter()
+                    .min_by_key(|idx| entries[*idx].credentials.priority)
+                    .unwrap(),
+            };
+
+            let selected = &entries[selected_index];
+            return CredentialSelection::Ready(selected.id, selected.credentials.clone());
+        }
+
+        if let Some(next) = earliest_wait {
+            CredentialSelection::WaitUntil(next)
+        } else {
+            CredentialSelection::NoneAvailable
         }
     }
 
@@ -721,30 +875,24 @@ impl MultiTokenManager {
                 );
             }
 
-            let (id, credentials) = {
-                let is_balanced = self.load_balancing_mode.lock().as_str() == "balanced";
+            let (id, credentials) = match self.select_next_credential(model) {
+                CredentialSelection::Ready(id, credentials) => {
+                    let mut current_id = self.current_id.lock();
+                    *current_id = id;
+                    (id, credentials)
+                }
+                CredentialSelection::WaitUntil(next) => {
+                    let now = Instant::now();
+                    if let Some(wait) = next.checked_duration_since(now) {
+                        tracing::debug!("所有可用凭据均处于限流中，等待 {:?} 后重试", wait);
+                        sleep_until(TokioInstant::from_std(next)).await;
+                    }
+                    continue;
+                }
+                CredentialSelection::NoneAvailable => {
+                    let mut best = None;
 
-                // balanced 模式：每次请求都重新均衡选择，不固定 current_id
-                // priority 模式：优先使用 current_id 指向的凭据
-                let current_hit = if is_balanced {
-                    None
-                } else {
-                    let entries = self.entries.lock();
-                    let current_id = *self.current_id.lock();
-                    entries
-                        .iter()
-                        .find(|e| e.id == current_id && !e.disabled)
-                        .map(|e| (e.id, e.credentials.clone()))
-                };
-
-                if let Some(hit) = current_hit {
-                    hit
-                } else {
-                    // 当前凭据不可用或 balanced 模式，根据负载均衡策略选择
-                    let mut best = self.select_next_credential(model);
-
-                    // 没有可用凭据：如果是"自动禁用导致全灭"，做一次类似重启的自愈
-                    if best.is_none() {
+                    {
                         let mut entries = self.entries.lock();
                         if entries.iter().any(|e| {
                             e.disabled && e.disabled_reason == Some(DisabledReason::TooManyFailures)
@@ -759,23 +907,23 @@ impl MultiTokenManager {
                                     e.failure_count = 0;
                                 }
                             }
-                            drop(entries);
-                            best = self.select_next_credential(model);
                         }
                     }
 
-                    if let Some((new_id, new_creds)) = best {
-                        // 更新 current_id
+                    if let CredentialSelection::Ready(id, credentials) =
+                        self.select_next_credential(model)
+                    {
+                        best = Some((id, credentials));
+                    }
+
+                    if let Some((id, credentials)) = best {
                         let mut current_id = self.current_id.lock();
-                        *current_id = new_id;
-                        (new_id, new_creds)
+                        *current_id = id;
+                        (id, credentials)
                     } else {
                         let entries = self.entries.lock();
-                        // 注意：必须在 bail! 之前计算 available_count，
-                        // 因为 available_count() 会尝试获取 entries 锁，
-                        // 而此时我们已经持有该锁，会导致死锁
                         let available = entries.iter().filter(|e| !e.disabled).count();
-                        anyhow::bail!("所有凭据均已禁用（{}/{}）", available, total);
+                        anyhow::bail!("所有凭据均已禁用或不支持当前模型（{}/{}）", available, total);
                     }
                 }
             };
@@ -783,6 +931,7 @@ impl MultiTokenManager {
             // 尝试获取/刷新 Token
             match self.try_ensure_token(id, &credentials).await {
                 Ok(ctx) => {
+                    self.reserve_rate_limit_slot(id, Instant::now());
                     return Ok(ctx);
                 }
                 Err(e) => {
@@ -861,8 +1010,9 @@ impl MultiTokenManager {
             if is_token_expired(&current_creds) || is_token_expiring_soon(&current_creds) {
                 // 确实需要刷新
                 let effective_proxy = current_creds.effective_proxy(self.proxy.as_ref());
+                let config = self.config();
                 let new_creds =
-                    refresh_token(&current_creds, &self.config, effective_proxy.as_ref()).await?;
+                    refresh_token(&current_creds, &config, effective_proxy.as_ref()).await?;
 
                 if is_token_expired(&new_creds) {
                     anyhow::bail!("刷新后的 Token 仍然无效或已过期");
@@ -1337,41 +1487,62 @@ impl MultiTokenManager {
 
     /// 获取管理器状态快照（用于 Admin API）
     pub fn snapshot(&self) -> ManagerSnapshot {
-        let entries = self.entries.lock();
+        let config = self.config();
+        let now = Instant::now();
+        let wall_now = Utc::now();
+        let mut entries = self.entries.lock();
         let current_id = *self.current_id.lock();
         let available = entries.iter().filter(|e| !e.disabled).count();
 
         ManagerSnapshot {
             entries: entries
-                .iter()
-                .map(|e| CredentialEntrySnapshot {
-                    id: e.id,
-                    priority: e.credentials.priority,
-                    disabled: e.disabled,
-                    failure_count: e.failure_count,
-                    auth_method: e.credentials.auth_method.as_deref().map(|m| {
-                        if m.eq_ignore_ascii_case("builder-id") || m.eq_ignore_ascii_case("iam") {
-                            "idc".to_string()
-                        } else {
-                            m.to_string()
+                .iter_mut()
+                .map(|e| {
+                    let effective_rate_limits = e.credentials.effective_rate_limits(&config);
+                    let resolved = Self::effective_resolved_rate_limits(&e.credentials, &config);
+                    let rate_limit_availability =
+                        Self::check_rate_limit(&mut e.rate_limit_state, &resolved, now);
+                    let next_available_at = match rate_limit_availability {
+                        RateLimitAvailability::Ready => None,
+                        RateLimitAvailability::LimitedUntil(next) => {
+                            Self::instant_to_rfc3339(next, now, wall_now)
                         }
-                    }),
-                    has_profile_arn: e.credentials.profile_arn.is_some(),
-                    expires_at: e.credentials.expires_at.clone(),
-                    refresh_token_hash: e.credentials.refresh_token.as_deref().map(sha256_hex),
-                    email: e.credentials.email.clone(),
-                    success_count: e.success_count,
-                    last_used_at: e.last_used_at.clone(),
-                    has_proxy: e.credentials.proxy_url.is_some(),
-                    proxy_url: e.credentials.proxy_url.clone(),
-                    refresh_failure_count: e.refresh_failure_count,
-                    disabled_reason: e.disabled_reason.map(|r| match r {
-                        DisabledReason::Manual => "Manual",
-                        DisabledReason::TooManyFailures => "TooManyFailures",
-                        DisabledReason::TooManyRefreshFailures => "TooManyRefreshFailures",
-                        DisabledReason::QuotaExceeded => "QuotaExceeded",
-                        DisabledReason::InvalidRefreshToken => "InvalidRefreshToken",
-                    }.to_string()),
+                    };
+
+                    CredentialEntrySnapshot {
+                        id: e.id,
+                        priority: e.credentials.priority,
+                        disabled: e.disabled,
+                        failure_count: e.failure_count,
+                        auth_method: e.credentials.auth_method.as_deref().map(|m| {
+                            if m.eq_ignore_ascii_case("builder-id") || m.eq_ignore_ascii_case("iam")
+                            {
+                                "idc".to_string()
+                            } else {
+                                m.to_string()
+                            }
+                        }),
+                        has_profile_arn: e.credentials.profile_arn.is_some(),
+                        expires_at: e.credentials.expires_at.clone(),
+                        refresh_token_hash: e.credentials.refresh_token.as_deref().map(sha256_hex),
+                        email: e.credentials.email.clone(),
+                        success_count: e.success_count,
+                        last_used_at: e.last_used_at.clone(),
+                        has_proxy: e.credentials.proxy_url.is_some(),
+                        proxy_url: e.credentials.proxy_url.clone(),
+                        refresh_failure_count: e.refresh_failure_count,
+                        disabled_reason: e.disabled_reason.map(|r| match r {
+                            DisabledReason::Manual => "Manual",
+                            DisabledReason::TooManyFailures => "TooManyFailures",
+                            DisabledReason::TooManyRefreshFailures => "TooManyRefreshFailures",
+                            DisabledReason::QuotaExceeded => "QuotaExceeded",
+                            DisabledReason::InvalidRefreshToken => "InvalidRefreshToken",
+                        }.to_string()),
+                        rate_limits: e.credentials.rate_limits.clone(),
+                        effective_rate_limits,
+                        rate_limited: next_available_at.is_some(),
+                        next_available_at,
+                    }
                 })
                 .collect(),
             current_id,
@@ -1423,6 +1594,27 @@ impl MultiTokenManager {
         Ok(())
     }
 
+    /// 设置凭据级限流规则（Admin API）
+    pub fn set_rate_limits(
+        &self,
+        id: u64,
+        rate_limits: Option<Vec<RateLimitRule>>,
+    ) -> anyhow::Result<()> {
+        let normalized = Self::normalize_optional_rate_limits(rate_limits, "credentials.rateLimits")?;
+
+        {
+            let mut entries = self.entries.lock();
+            let entry = entries
+                .iter_mut()
+                .find(|e| e.id == id)
+                .ok_or_else(|| anyhow::anyhow!("凭据不存在: {}", id))?;
+            entry.credentials.rate_limits = normalized;
+        }
+
+        self.persist_credentials()?;
+        Ok(())
+    }
+
     /// 重置凭据失败计数并重新启用（Admin API）
     pub fn reset_and_enable(&self, id: u64) -> anyhow::Result<()> {
         {
@@ -1468,8 +1660,9 @@ impl MultiTokenManager {
 
             if is_token_expired(&current_creds) || is_token_expiring_soon(&current_creds) {
                 let effective_proxy = current_creds.effective_proxy(self.proxy.as_ref());
+                let config = self.config();
                 let new_creds =
-                    refresh_token(&current_creds, &self.config, effective_proxy.as_ref()).await?;
+                    refresh_token(&current_creds, &config, effective_proxy.as_ref()).await?;
                 {
                     let mut entries = self.entries.lock();
                     if let Some(entry) = entries.iter_mut().find(|e| e.id == id) {
@@ -1504,7 +1697,9 @@ impl MultiTokenManager {
         };
 
         let effective_proxy = credentials.effective_proxy(self.proxy.as_ref());
-        let usage_limits = get_usage_limits(&credentials, &self.config, &token, effective_proxy.as_ref()).await?;
+        let config = self.config();
+        let usage_limits =
+            get_usage_limits(&credentials, &config, &token, effective_proxy.as_ref()).await?;
 
         // 更新订阅等级到凭据（仅在发生变化时持久化）
         if let Some(subscription_title) = usage_limits.subscription_title() {
@@ -1581,8 +1776,9 @@ impl MultiTokenManager {
 
         // 3. 尝试刷新 Token 验证凭据有效性
         let effective_proxy = new_cred.effective_proxy(self.proxy.as_ref());
+        let config = self.config();
         let mut validated_cred =
-            refresh_token(&new_cred, &self.config, effective_proxy.as_ref()).await?;
+            refresh_token(&new_cred, &config, effective_proxy.as_ref()).await?;
 
         // 4. 分配新 ID
         let new_id = {
@@ -1610,6 +1806,7 @@ impl MultiTokenManager {
         validated_cred.proxy_url = new_cred.proxy_url;
         validated_cred.proxy_username = new_cred.proxy_username;
         validated_cred.proxy_password = new_cred.proxy_password;
+        validated_cred.rate_limits = new_cred.rate_limits;
 
         {
             let mut entries = self.entries.lock();
@@ -1622,6 +1819,7 @@ impl MultiTokenManager {
                 disabled_reason: None,
                 success_count: 0,
                 last_used_at: None,
+                rate_limit_state: CredentialRateLimitState::default(),
             });
         }
 
@@ -1717,8 +1915,8 @@ impl MultiTokenManager {
 
         // 无条件调用 refresh_token
         let effective_proxy = credentials.effective_proxy(self.proxy.as_ref());
-        let new_creds =
-            refresh_token(&credentials, &self.config, effective_proxy.as_ref()).await?;
+        let config = self.config();
+        let new_creds = refresh_token(&credentials, &config, effective_proxy.as_ref()).await?;
 
         // 更新 entries 中对应凭据
         {
@@ -1738,6 +1936,30 @@ impl MultiTokenManager {
         Ok(())
     }
 
+    pub fn get_default_rate_limits(&self) -> Option<Vec<RateLimitRule>> {
+        self.config.read().default_rate_limits.clone()
+    }
+
+    pub fn set_default_rate_limits(
+        &self,
+        rate_limits: Option<Vec<RateLimitRule>>,
+    ) -> anyhow::Result<()> {
+        let normalized =
+            Self::normalize_optional_rate_limits(rate_limits, "config.defaultRateLimits")?;
+
+        let mut config = self.config.write();
+        let previous = config.default_rate_limits.clone();
+        config.default_rate_limits = normalized;
+
+        if let Err(err) = config.save() {
+            config.default_rate_limits = previous;
+            return Err(err);
+        }
+
+        tracing::info!("全局默认限流规则已更新");
+        Ok(())
+    }
+
     /// 获取负载均衡模式（Admin API）
     pub fn get_load_balancing_mode(&self) -> String {
         self.load_balancing_mode.lock().clone()
@@ -1746,7 +1968,8 @@ impl MultiTokenManager {
     fn persist_load_balancing_mode(&self, mode: &str) -> anyhow::Result<()> {
         use anyhow::Context;
 
-        let config_path = match self.config.config_path() {
+        let config = self.config();
+        let config_path = match config.config_path() {
             Some(path) => path.to_path_buf(),
             None => {
                 tracing::warn!("配置文件路径未知，负载均衡模式仅在当前进程生效: {}", mode);
@@ -2022,6 +2245,55 @@ mod tests {
         assert_eq!(manager.get_load_balancing_mode(), "balanced");
 
         std::fs::remove_file(&config_path).unwrap();
+    }
+
+    #[test]
+    fn test_snapshot_marks_rate_limited_credential() {
+        let mut config = Config::default();
+        config.default_rate_limits = Some(vec![RateLimitRule {
+            window: "1m".to_string(),
+            max_requests: 1,
+        }]);
+
+        let mut credential = KiroCredentials::default();
+        credential.access_token = Some("token".to_string());
+        credential.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+
+        let manager = MultiTokenManager::new(config, vec![credential], None, None, false).unwrap();
+        manager.reserve_rate_limit_slot(1, Instant::now());
+
+        let snapshot = manager.snapshot();
+        let entry = &snapshot.entries[0];
+        assert!(entry.rate_limited);
+        assert!(entry.next_available_at.is_some());
+        assert_eq!(entry.effective_rate_limits.len(), 1);
+        assert_eq!(entry.effective_rate_limits[0].window, "1m");
+    }
+
+    #[tokio::test]
+    async fn test_acquire_context_skips_rate_limited_current_credential() {
+        let config = Config::default();
+
+        let mut cred1 = KiroCredentials::default();
+        cred1.access_token = Some("t1".to_string());
+        cred1.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+        cred1.rate_limits = Some(vec![RateLimitRule {
+            window: "1m".to_string(),
+            max_requests: 1,
+        }]);
+
+        let mut cred2 = KiroCredentials::default();
+        cred2.access_token = Some("t2".to_string());
+        cred2.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+
+        let manager =
+            MultiTokenManager::new(config, vec![cred1, cred2], None, None, false).unwrap();
+
+        manager.reserve_rate_limit_slot(1, Instant::now());
+        let ctx = manager.acquire_context(None).await.unwrap();
+
+        assert_eq!(ctx.id, 2);
+        assert_eq!(ctx.token, "t2");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,11 @@ async fn main() {
         tracing::info!("  GET  /api/admin/credentials");
         tracing::info!("  POST /api/admin/credentials/:index/disabled");
         tracing::info!("  POST /api/admin/credentials/:index/priority");
+        tracing::info!("  POST /api/admin/credentials/:index/rate-limits");
         tracing::info!("  POST /api/admin/credentials/:index/reset");
         tracing::info!("  GET  /api/admin/credentials/:index/balance");
+        tracing::info!("  GET  /api/admin/config/rate-limits");
+        tracing::info!("  PUT  /api/admin/config/rate-limits");
         tracing::info!("Admin UI:");
         tracing::info!("  GET  /admin");
     }

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -230,7 +230,8 @@ impl Config {
             .ok_or_else(|| anyhow::anyhow!("配置文件路径未知，无法保存配置"))?;
 
         let content = serde_json::to_string_pretty(self).context("序列化配置失败")?;
-        fs::write(path, content).with_context(|| format!("写入配置文件失败: {}", path.display()))?;
+        fs::write(path, content)
+            .with_context(|| format!("写入配置文件失败: {}", path.display()))?;
         Ok(())
     }
 }

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::model::rate_limit::{RateLimitRule, validate_rate_limit_rules};
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum TlsBackend {
@@ -86,6 +88,11 @@ pub struct Config {
     #[serde(default)]
     pub admin_api_key: Option<String>,
 
+    /// 全局默认限流规则（每个凭据的默认值）
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_rate_limits: Option<Vec<RateLimitRule>>,
+
     /// 负载均衡模式（"priority" 或 "balanced"）
     #[serde(default = "default_load_balancing_mode")]
     pub load_balancing_mode: String,
@@ -164,6 +171,7 @@ impl Default for Config {
             proxy_username: None,
             proxy_password: None,
             admin_api_key: None,
+            default_rate_limits: None,
             load_balancing_mode: default_load_balancing_mode(),
             extract_thinking: default_extract_thinking(),
             config_path: None,
@@ -201,6 +209,10 @@ impl Config {
 
         let content = fs::read_to_string(path)?;
         let mut config: Config = serde_json::from_str(&content)?;
+        validate_rate_limit_rules(
+            config.default_rate_limits.as_deref(),
+            "config.defaultRateLimits",
+        )?;
         config.config_path = Some(path.to_path_buf());
         Ok(config)
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod arg;
 pub mod config;
+pub mod rate_limit;

--- a/src/model/rate_limit.rs
+++ b/src/model/rate_limit.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, bail};
+use serde::{Deserialize, Serialize};
+
+pub const MAX_RATE_LIMIT_WINDOW_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// 可序列化的限流规则
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitRule {
+    /// 时间窗口，格式为 `正整数 + 单位`
+    /// 例如：`30s`、`5m`、`2h`、`1d`
+    pub window: String,
+    /// 该时间窗口内允许的最大请求数
+    pub max_requests: u32,
+}
+
+/// 已解析并规范化的限流规则
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRateLimitRule {
+    pub window: String,
+    pub window_seconds: u64,
+    pub max_requests: u32,
+}
+
+pub fn parse_window_seconds(window: &str) -> anyhow::Result<u64> {
+    if window.len() < 2 {
+        bail!("时间窗口格式无效: {}", window);
+    }
+
+    let (number_part, unit_part) = window.split_at(window.len() - 1);
+    if number_part.is_empty() || !number_part.chars().all(|c| c.is_ascii_digit()) {
+        bail!("时间窗口必须是正整数加单位: {}", window);
+    }
+
+    let value = number_part
+        .parse::<u64>()
+        .with_context(|| format!("时间窗口数值无效: {}", window))?;
+    if value == 0 {
+        bail!("时间窗口必须大于 0: {}", window);
+    }
+
+    let multiplier = match unit_part {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 24 * 60 * 60,
+        _ => bail!("不支持的时间单位: {}", window),
+    };
+
+    let seconds = value
+        .checked_mul(multiplier)
+        .ok_or_else(|| anyhow::anyhow!("时间窗口过大: {}", window))?;
+    if seconds > MAX_RATE_LIMIT_WINDOW_SECS {
+        bail!(
+            "时间窗口不能超过 {} 秒（当前: {}）",
+            MAX_RATE_LIMIT_WINDOW_SECS,
+            window
+        );
+    }
+
+    Ok(seconds)
+}
+
+pub fn canonical_window(seconds: u64) -> String {
+    if seconds.is_multiple_of(24 * 60 * 60) {
+        format!("{}d", seconds / (24 * 60 * 60))
+    } else if seconds.is_multiple_of(60 * 60) {
+        format!("{}h", seconds / (60 * 60))
+    } else if seconds.is_multiple_of(60) {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{}s", seconds)
+    }
+}
+
+pub fn resolve_rate_limit_rules(
+    rules: &[RateLimitRule],
+    source: &str,
+) -> anyhow::Result<Vec<ResolvedRateLimitRule>> {
+    let mut by_window = BTreeMap::new();
+
+    for rule in rules {
+        if rule.max_requests == 0 {
+            bail!("{} 中 maxRequests 必须大于 0: {}", source, rule.window);
+        }
+
+        let seconds = parse_window_seconds(&rule.window)
+            .with_context(|| format!("{} 中存在非法窗口", source))?;
+        let normalized = ResolvedRateLimitRule {
+            window: canonical_window(seconds),
+            window_seconds: seconds,
+            max_requests: rule.max_requests,
+        };
+
+        if by_window.insert(seconds, normalized).is_some() {
+            bail!("{} 中存在重复的时间窗口: {}", source, rule.window);
+        }
+    }
+
+    Ok(by_window.into_values().collect())
+}
+
+pub fn validate_rate_limit_rules(
+    rules: Option<&[RateLimitRule]>,
+    source: &str,
+) -> anyhow::Result<()> {
+    if let Some(rules) = rules {
+        resolve_rate_limit_rules(rules, source)?;
+    }
+    Ok(())
+}
+
+pub fn effective_rate_limit_rules(
+    defaults: Option<&[RateLimitRule]>,
+    overrides: Option<&[RateLimitRule]>,
+) -> anyhow::Result<Vec<RateLimitRule>> {
+    let chosen = if let Some(overrides) = overrides {
+        resolve_rate_limit_rules(overrides, "rateLimits")?
+    } else if let Some(defaults) = defaults {
+        resolve_rate_limit_rules(defaults, "defaultRateLimits")?
+    } else {
+        Vec::new()
+    };
+
+    Ok(chosen
+        .into_iter()
+        .map(|rule| RateLimitRule {
+            window: canonical_window(rule.window_seconds),
+            max_requests: rule.max_requests,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_window_seconds() {
+        assert_eq!(parse_window_seconds("30s").unwrap(), 30);
+        assert_eq!(parse_window_seconds("5m").unwrap(), 300);
+        assert_eq!(parse_window_seconds("2h").unwrap(), 7200);
+        assert_eq!(parse_window_seconds("1d").unwrap(), 86400);
+    }
+
+    #[test]
+    fn test_parse_window_seconds_rejects_invalid() {
+        assert!(parse_window_seconds("0m").is_err());
+        assert!(parse_window_seconds("1.5h").is_err());
+        assert!(parse_window_seconds("abc").is_err());
+        assert!(parse_window_seconds("31d").is_err());
+    }
+
+    #[test]
+    fn test_effective_rate_limit_rules_prefers_override_set() {
+        let defaults = vec![
+            RateLimitRule {
+                window: "5m".to_string(),
+                max_requests: 100,
+            },
+            RateLimitRule {
+                window: "24h".to_string(),
+                max_requests: 3000,
+            },
+        ];
+        let overrides = vec![
+            RateLimitRule {
+                window: "2m".to_string(),
+                max_requests: 20,
+            },
+            RateLimitRule {
+                window: "1d".to_string(),
+                max_requests: 2000,
+            },
+        ];
+
+        let merged = effective_rate_limit_rules(Some(&defaults), Some(&overrides)).unwrap();
+
+        assert_eq!(
+            merged,
+            vec![
+                RateLimitRule {
+                    window: "2m".to_string(),
+                    max_requests: 20,
+                },
+                RateLimitRule {
+                    window: "1d".to_string(),
+                    max_requests: 2000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_effective_rate_limit_rules_falls_back_to_defaults() {
+        let defaults = vec![RateLimitRule {
+            window: "5m".to_string(),
+            max_requests: 100,
+        }];
+
+        let effective = effective_rate_limit_rules(Some(&defaults), None).unwrap();
+
+        assert_eq!(effective, defaults);
+    }
+}


### PR DESCRIPTION
  ## Summary

  这个 PR 为多凭据场景增加了可配置的限流能力，并补齐了管理端配置与运行态展示。
  
  ### 后端
  - 新增通用限流规则模型，支持 `30s`、`5m`、`2h`、`1d` 等时间窗口
  - 支持全局默认限流规则 `defaultRateLimits`
  - 支持凭据级限流规则 `rateLimits`
  - 在 `MultiTokenManager` 中增加限流校验与运行时状态维护
  - 当单个凭据命中限流时，自动切换到其他可用凭据
  - 当所有凭据都处于限流中时，等待最早恢复的凭据，而不是直接失败
  - 通过 Admin API 暴露限流配置和运行态信息

  ### 管理端
  - 新增全局默认限流配置入口
  - 新增凭据级限流编辑入口
  - 新增限流规则编辑弹窗，支持多条窗口规则配置
  - 凭据卡片直接展示限流运行态
  - 限流状态中优先展示剩余次数最少的前两条窗口
  - 删除单独的“限流规则”展示行，避免与状态摘要重复

  ### 文档 / 工具
  - 更新 README，补充限流配置与行为说明
  - 新增 `build-kiro-rs-image` 技能和构建脚本，便于构建并推送 `linux/amd64` 镜像

  ## Testing

  - `cargo test test_snapshot_`
  - `pnpm build`

  ## Notes

  - 限流采用滑动窗口模型
  - 凭据级 `rateLimits` 会完整覆盖全局默认规则
  - 限流运行态只保存在内存中
  - 限流规则配置会持久化