### PR TITLE
新增 Opus 4.7 支持及切换 Endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,19 +388,26 @@ RUST_LOG=debug ./target/release/kiro-rs
 
 ### Thinking 模式
 
-支持 Claude 的 extended thinking 功能：
+支持 Claude 的 extended thinking / adaptive thinking 功能：
 
 ```json
 {
-  "model": "claude-sonnet-4-20250514",
-  "max_tokens": 16000,
+  "model": "claude-sonnet-4-6",
+  "max_tokens": 64000,
   "thinking": {
-    "type": "enabled",
-    "budget_tokens": 10000
+    "type": "adaptive"
+  },
+  "output_config": {
+    "effort": "medium"
   },
   "messages": [...]
 }
 ```
+
+对于 `claude-opus-4-7-thinking`、`claude-opus-4-6-thinking`、`claude-sonnet-4-6-thinking`
+这类便捷模型名，服务会自动补齐 `thinking.type = "adaptive"`；如果客户端传入
+`output_config.effort`，服务会保留该值，未传时默认 `high`。旧的 4.5/Haiku thinking
+别名会使用 `thinking.type = "enabled"` 和 `budget_tokens`。
 
 ### 工具调用
 
@@ -431,8 +438,10 @@ RUST_LOG=debug ./target/release/kiro-rs
 
 | Anthropic 模型 | Kiro 模型 |
 |----------------|-----------|
-| `*sonnet*` | `claude-sonnet-4.5` |
+| `*sonnet*`（含 4.6/4-6） | `claude-sonnet-4.6` |
+| `*sonnet*`（其他） | `claude-sonnet-4.5` |
 | `*opus*`（含 4.5/4-5） | `claude-opus-4.5` |
+| `*opus*`（含 4.7/4-7） | `claude-opus-4.7` |
 | `*opus*`（其他） | `claude-opus-4.6` |
 | `*haiku*` | `claude-haiku-4.5` |
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,24 @@ docker-compose up
    "proxyPassword": "pass",
    "adminApiKey": "sk-admin-your-secret-key",
    "loadBalancingMode": "priority",
+   "defaultEndpoint": "ide",
    "extractThinking": true
+}
+```
+
+#### Kiro 端点
+
+所有 Kiro API 请求默认使用 `ide` 端点名称；该名称保留用于配置兼容，内部请求已切换到新的 Kiro 端点：
+
+- API: `https://runtime.{apiRegion}.kiro.dev/generateAssistantResponse`
+- MCP / WebSearch: `https://runtime.{apiRegion}.kiro.dev/mcp`
+- 余额/订阅等级: `https://management.{apiRegion}.kiro.dev/getUsageLimits`
+
+如需显式配置端点名称，可使用：
+
+```json
+{
+   "defaultEndpoint": "ide"
 }
 ```
 

--- a/src/infra/endpoint/ide.rs
+++ b/src/infra/endpoint/ide.rs
@@ -1,7 +1,10 @@
-//! Kiro IDE 端点（迁移自 `kiro::endpoint::ide`）
+//! Kiro IDE 端点。
 //!
-//! - API: `https://q.{api_region}.amazonaws.com/generateAssistantResponse`
-//! - MCP: `https://q.{api_region}.amazonaws.com/mcp`
+//! `ide` 是配置层面的端点名称，为了兼容现有 `defaultEndpoint` / 凭据 `endpoint`
+//! 配置继续保留；实际请求地址使用新的 Kiro runtime host。
+//!
+//! - API: `https://runtime.{api_region}.kiro.dev/generateAssistantResponse`
+//! - MCP: `https://runtime.{api_region}.kiro.dev/mcp`
 
 use uuid::Uuid;
 
@@ -21,7 +24,7 @@ impl IdeEndpoint {
     }
 
     fn host(&self, ctx: &RequestContext<'_>) -> String {
-        format!("q.{}.amazonaws.com", self.api_region(ctx))
+        format!("runtime.{}.kiro.dev", self.api_region(ctx))
     }
 
     fn x_amz_user_agent(&self, ctx: &RequestContext<'_>) -> String {
@@ -55,13 +58,13 @@ impl KiroEndpoint for IdeEndpoint {
 
     fn api_url(&self, ctx: &RequestContext<'_>) -> String {
         format!(
-            "https://q.{}.amazonaws.com/generateAssistantResponse",
+            "https://runtime.{}.kiro.dev/generateAssistantResponse",
             self.api_region(ctx)
         )
     }
 
     fn mcp_url(&self, ctx: &RequestContext<'_>) -> String {
-        format!("https://q.{}.amazonaws.com/mcp", self.api_region(ctx))
+        format!("https://runtime.{}.kiro.dev/mcp", self.api_region(ctx))
     }
 
     fn api_headers(&self, ctx: &RequestContext<'_>) -> Vec<(String, String)> {
@@ -118,42 +121,88 @@ fn inject_profile_arn(request_body: &str, profile_arn: &Option<String>) -> Strin
 
 #[cfg(test)]
 mod tests {
-    use super::inject_profile_arn;
-    use serde_json::Value;
+    use crate::config::Config;
+    use crate::domain::credential::Credential;
+    use crate::domain::endpoint::{KiroEndpoint, RequestContext};
 
-    #[test]
-    fn test_inject_profile_arn_with_some() {
-        let body = r#"{"conversationState":{"conversationId":"c1"}}"#;
-        let arn = Some("arn:aws:codewhisperer:us-east-1:123:profile/ABC".to_string());
-        let result = inject_profile_arn(body, &arn);
-        let json: Value = serde_json::from_str(&result).unwrap();
-        assert_eq!(
-            json["profileArn"],
-            "arn:aws:codewhisperer:us-east-1:123:profile/ABC"
-        );
-        assert_eq!(json["conversationState"]["conversationId"], "c1");
+    use super::*;
+
+    fn ctx<'a>(cred: &'a Credential, config: &'a Config) -> RequestContext<'a> {
+        RequestContext {
+            credentials: cred,
+            token: "token",
+            machine_id: "machine",
+            config,
+        }
     }
 
     #[test]
-    fn test_inject_profile_arn_with_none() {
+    fn endpoint_name_remains_ide() {
+        assert_eq!(IdeEndpoint::new().name(), "ide");
+    }
+
+    #[test]
+    fn urls_use_runtime_host() {
+        let endpoint = IdeEndpoint::new();
+        let config = Config::default();
+        let cred = Credential::default();
+        let ctx = ctx(&cred, &config);
+
+        assert_eq!(
+            endpoint.api_url(&ctx),
+            "https://runtime.us-east-1.kiro.dev/generateAssistantResponse"
+        );
+        assert_eq!(
+            endpoint.mcp_url(&ctx),
+            "https://runtime.us-east-1.kiro.dev/mcp"
+        );
+    }
+
+    #[test]
+    fn credential_api_region_overrides_config_region() {
+        let endpoint = IdeEndpoint::new();
+        let config = Config::default();
+        let cred = Credential {
+            api_region: Some("eu-central-1".into()),
+            ..Default::default()
+        };
+        let ctx = ctx(&cred, &config);
+
+        assert_eq!(
+            endpoint.api_url(&ctx),
+            "https://runtime.eu-central-1.kiro.dev/generateAssistantResponse"
+        );
+    }
+
+    #[test]
+    fn injects_profile_arn() {
+        let body = r#"{"conversationState":{"conversationId":"c1"}}"#;
+        let arn = Some("arn:test".to_string());
+        let result = inject_profile_arn(body, &arn);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["profileArn"], "arn:test");
+    }
+
+    #[test]
+    fn inject_profile_arn_with_none_keeps_body_without_profile() {
         let body = r#"{"conversationState":{"conversationId":"c1"}}"#;
         let result = inject_profile_arn(body, &None);
-        let json: Value = serde_json::from_str(&result).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(json.get("profileArn").is_none());
         assert_eq!(json["conversationState"]["conversationId"], "c1");
     }
 
     #[test]
-    fn test_inject_profile_arn_overwrites_existing() {
+    fn inject_profile_arn_overwrites_existing() {
         let body = r#"{"conversationState":{},"profileArn":"old-arn"}"#;
         let arn = Some("new-arn".to_string());
         let result = inject_profile_arn(body, &arn);
-        let json: Value = serde_json::from_str(&result).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(json["profileArn"], "new-arn");
     }
 
     #[test]
-    fn test_inject_profile_arn_invalid_json() {
+    fn inject_profile_arn_invalid_json_returns_original_body() {
         let body = "not-valid-json";
         let arn = Some("arn:test".to_string());
         let result = inject_profile_arn(body, &arn);

--- a/src/interface/http/anthropic/dto.rs
+++ b/src/interface/http/anthropic/dto.rs
@@ -60,19 +60,15 @@ pub struct ModelsResponse {
 
 // === Messages 端点类型 ===
 
-/// 最大思考预算 tokens
-const MAX_BUDGET_TOKENS: i32 = 24576;
-
 /// Thinking 配置
 #[derive(Debug, Deserialize, Clone)]
 pub struct Thinking {
     #[serde(rename = "type")]
     pub thinking_type: String,
-    #[serde(
-        default = "default_budget_tokens",
-        deserialize_with = "deserialize_budget_tokens"
-    )]
+    #[serde(default = "default_budget_tokens")]
     pub budget_tokens: i32,
+    #[serde(default)]
+    pub display: Option<String>,
 }
 
 impl Thinking {
@@ -84,13 +80,6 @@ impl Thinking {
 
 fn default_budget_tokens() -> i32 {
     20000
-}
-fn deserialize_budget_tokens<'de, D>(deserializer: D) -> Result<i32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = i32::deserialize(deserializer)?;
-    Ok(value.min(MAX_BUDGET_TOKENS))
 }
 
 /// OutputConfig 配置

--- a/src/interface/http/anthropic/handlers.rs
+++ b/src/interface/http/anthropic/handlers.rs
@@ -26,7 +26,7 @@ use super::dto::{
     OutputConfig, Thinking,
 };
 use super::middleware::AppState;
-use super::models::supported_models;
+use super::models::{model_max_tokens, supported_models};
 use crate::interface::http::error::kiro_error_response;
 use crate::service::conversation::converter::{ConversionError, convert_request};
 use crate::service::conversation::delivery::DeliveryMode;
@@ -111,8 +111,17 @@ async fn post_messages_impl(
         }
     };
 
-    // 检测模型名是否包含 "thinking" 后缀，若包含则覆写 thinking 配置
+    // 检测模型名是否包含 "thinking" 后缀，若包含则补齐 thinking 配置
     override_thinking_from_model_name(&mut payload);
+
+    if let Err(message) = validate_messages_request(&payload) {
+        tracing::warn!(model = %payload.model, error = %message, "请求参数校验失败");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("invalid_request_error", message)),
+        )
+            .into_response();
+    }
 
     // 检查是否为 WebSearch 请求
     if websearch::has_web_search_tool(&payload) {
@@ -533,9 +542,8 @@ async fn handle_non_stream_request(
             Event::ContextUsage(context_usage) => {
                 // 从上下文使用百分比计算实际的 input_tokens
                 let window_size = get_context_window_size(model);
-                let actual_input_tokens = (context_usage.context_usage_percentage
-                    * (window_size as f64)
-                    / 100.0) as i32;
+                let actual_input_tokens =
+                    (context_usage.context_usage_percentage * (window_size as f64) / 100.0) as i32;
                 context_input_tokens = Some(actual_input_tokens);
                 // 上下文使用量达到 100% 时，设置 stop_reason 为 model_context_window_exceeded
                 if context_usage.context_usage_percentage >= 100.0 {
@@ -647,21 +655,136 @@ async fn handle_non_stream_request(
     (StatusCode::OK, Json(response_body)).into_response()
 }
 
-/// 检测模型名是否包含 "thinking" 后缀，若包含则覆写 thinking 配置
+fn model_is_opus_4_7(model_lower: &str) -> bool {
+    model_lower.contains("opus") && (model_lower.contains("4-7") || model_lower.contains("4.7"))
+}
+
+fn model_is_opus_4_6(model_lower: &str) -> bool {
+    model_lower.contains("opus") && (model_lower.contains("4-6") || model_lower.contains("4.6"))
+}
+
+fn model_is_sonnet_4_6(model_lower: &str) -> bool {
+    model_lower.contains("sonnet") && (model_lower.contains("4-6") || model_lower.contains("4.6"))
+}
+
+fn model_supports_adaptive_thinking(model_lower: &str) -> bool {
+    model_is_opus_4_7(model_lower)
+        || model_is_opus_4_6(model_lower)
+        || model_is_sonnet_4_6(model_lower)
+}
+
+fn default_alias_budget(max_tokens: i32) -> i32 {
+    if max_tokens > 20000 {
+        20000
+    } else {
+        max_tokens.saturating_sub(1).max(1)
+    }
+}
+
+fn validate_effort_for_model(model_lower: &str, effort: &str) -> bool {
+    match effort {
+        "low" | "medium" | "high" => true,
+        "max" => model_supports_adaptive_thinking(model_lower),
+        "xhigh" => model_is_opus_4_7(model_lower),
+        _ => false,
+    }
+}
+
+fn validate_messages_request(payload: &MessagesRequest) -> Result<(), String> {
+    if payload.max_tokens <= 0 {
+        return Err("max_tokens must be greater than 0".to_string());
+    }
+
+    let model_limit = model_max_tokens(&payload.model);
+    if payload.max_tokens > model_limit {
+        return Err(format!(
+            "max_tokens exceeds model limit: {} > {}",
+            payload.max_tokens, model_limit
+        ));
+    }
+
+    validate_thinking_config(payload)
+}
+
+fn validate_thinking_config(payload: &MessagesRequest) -> Result<(), String> {
+    let Some(thinking) = &payload.thinking else {
+        return Ok(());
+    };
+
+    let model_lower = payload.model.to_lowercase();
+    let thinking_type = thinking.thinking_type.as_str();
+
+    if let Some(display) = thinking.display.as_deref()
+        && display != "omitted"
+        && display != "summarized"
+    {
+        return Err(format!("unsupported thinking.display: {display}"));
+    }
+
+    match thinking_type {
+        "disabled" => Ok(()),
+        "enabled" => {
+            if model_is_opus_4_7(&model_lower) {
+                return Err(
+                    "claude-opus-4.7 only supports adaptive thinking; enabled is unsupported"
+                        .to_string(),
+                );
+            }
+            if thinking.budget_tokens <= 0 {
+                return Err("thinking.budget_tokens must be greater than 0".to_string());
+            }
+            if thinking.budget_tokens >= payload.max_tokens {
+                return Err(format!(
+                    "thinking.budget_tokens must be less than max_tokens: {} >= {}",
+                    thinking.budget_tokens, payload.max_tokens
+                ));
+            }
+            Ok(())
+        }
+        "adaptive" => {
+            if !model_supports_adaptive_thinking(&model_lower) {
+                return Err(format!(
+                    "{} does not support adaptive thinking",
+                    payload.model
+                ));
+            }
+            let effort = payload
+                .output_config
+                .as_ref()
+                .map(|c| c.effort.as_str())
+                .unwrap_or("high");
+            if !validate_effort_for_model(&model_lower, effort) {
+                return Err(format!(
+                    "unsupported output_config.effort for {}: {}",
+                    payload.model, effort
+                ));
+            }
+            Ok(())
+        }
+        other => Err(format!("unsupported thinking.type: {other}")),
+    }
+}
+
+/// 检测模型名是否包含 "thinking" 后缀，若包含则补齐 thinking 配置
 ///
-/// - Opus 4.6：覆写为 adaptive 类型
-/// - 其他模型：覆写为 enabled 类型
-/// - budget_tokens 固定为 20000
+/// - Opus 4.6 / 4.7 / Sonnet 4.6：补齐为 adaptive 类型；
+/// - 其他模型：补齐为 enabled 类型；
+/// - 客户端传入的 output_config.effort 优先，未传时 adaptive 默认 high。
 fn override_thinking_from_model_name(payload: &mut MessagesRequest) {
     let model_lower = payload.model.to_lowercase();
     if !model_lower.contains("thinking") {
         return;
     }
 
-    let is_opus_4_6 = model_lower.contains("opus")
-        && (model_lower.contains("4-6") || model_lower.contains("4.6"));
+    let is_adaptive = model_supports_adaptive_thinking(&model_lower);
 
-    let thinking_type = if is_opus_4_6 { "adaptive" } else { "enabled" };
+    let thinking_type = if is_adaptive { "adaptive" } else { "enabled" };
+    let existing_thinking = payload.thinking.clone();
+    let budget_tokens = existing_thinking
+        .as_ref()
+        .map(|t| t.budget_tokens)
+        .unwrap_or_else(|| default_alias_budget(payload.max_tokens));
+    let display = existing_thinking.and_then(|t| t.display);
 
     tracing::info!(
         model = %payload.model,
@@ -671,10 +794,11 @@ fn override_thinking_from_model_name(payload: &mut MessagesRequest) {
 
     payload.thinking = Some(Thinking {
         thinking_type: thinking_type.to_string(),
-        budget_tokens: 20000,
+        budget_tokens,
+        display,
     });
 
-    if is_opus_4_6 {
+    if is_adaptive && payload.output_config.is_none() {
         payload.output_config = Some(OutputConfig {
             effort: "high".to_string(),
         });
@@ -879,6 +1003,158 @@ mod tests {
             output_config: None,
             metadata: None,
         }
+    }
+
+    fn request_with_model(model: &str) -> MessagesRequest {
+        let mut req = empty_request();
+        req.model = model.to_string();
+        req
+    }
+
+    fn thinking(thinking_type: &str, budget_tokens: i32) -> Thinking {
+        Thinking {
+            thinking_type: thinking_type.to_string(),
+            budget_tokens,
+            display: None,
+        }
+    }
+
+    /// Opus 4.7 的 `-thinking` 后缀必须走 adaptive + effort=high。
+    #[test]
+    fn override_thinking_opus_4_7_uses_adaptive_high() {
+        let mut req = request_with_model("claude-opus-4-7-thinking");
+        req.max_tokens = 128000;
+        override_thinking_from_model_name(&mut req);
+        let t = req.thinking.expect("thinking 应被覆写");
+        assert_eq!(t.thinking_type, "adaptive");
+        assert_eq!(t.budget_tokens, 20000);
+        let oc = req.output_config.expect("output_config 应被设置为 high");
+        assert_eq!(oc.effort, "high");
+    }
+
+    /// Opus 4.6 的 `-thinking` 后缀行为回归保护：adaptive + effort=high。
+    #[test]
+    fn override_thinking_opus_4_6_uses_adaptive_high() {
+        let mut req = request_with_model("claude-opus-4-6-thinking");
+        req.max_tokens = 128000;
+        override_thinking_from_model_name(&mut req);
+        let t = req.thinking.expect("thinking 应被覆写");
+        assert_eq!(t.thinking_type, "adaptive");
+        let oc = req.output_config.expect("output_config 应被设置为 high");
+        assert_eq!(oc.effort, "high");
+    }
+
+    /// Sonnet 4.6 的 `-thinking` 后缀也应走 adaptive。
+    #[test]
+    fn override_thinking_sonnet_4_6_uses_adaptive_high() {
+        let mut req = request_with_model("claude-sonnet-4-6-thinking");
+        req.max_tokens = 64000;
+        override_thinking_from_model_name(&mut req);
+        let t = req.thinking.expect("thinking 应被覆写");
+        assert_eq!(t.thinking_type, "adaptive");
+        assert_eq!(t.budget_tokens, 20000);
+        let oc = req.output_config.expect("output_config 应被设置为 high");
+        assert_eq!(oc.effort, "high");
+    }
+
+    /// 客户端显式传入的 effort 不能被 `-thinking` 别名覆盖。
+    #[test]
+    fn override_thinking_preserves_client_effort() {
+        let mut req = request_with_model("claude-sonnet-4-6-thinking");
+        req.max_tokens = 64000;
+        req.output_config = Some(OutputConfig {
+            effort: "medium".to_string(),
+        });
+        override_thinking_from_model_name(&mut req);
+        let t = req.thinking.expect("thinking 应被覆写");
+        assert_eq!(t.thinking_type, "adaptive");
+        let oc = req.output_config.expect("output_config 应保留");
+        assert_eq!(oc.effort, "medium");
+    }
+
+    /// 非 adaptive 能力模型的 `-thinking` 后缀走 enabled 分支，不设置 output_config。
+    #[test]
+    fn override_thinking_legacy_model_uses_enabled_without_output_config() {
+        let mut req = request_with_model("claude-haiku-4-5-20251001-thinking");
+        req.max_tokens = 64000;
+        override_thinking_from_model_name(&mut req);
+        let t = req.thinking.expect("thinking 应被覆写");
+        assert_eq!(t.thinking_type, "enabled");
+        assert_eq!(t.budget_tokens, 20000);
+        assert!(
+            req.output_config.is_none(),
+            "非 adaptive 模型不应设置 output_config"
+        );
+    }
+
+    /// 模型名里没有 `thinking` 后缀时，override 函数应完全不动 payload。
+    #[test]
+    fn override_thinking_no_suffix_is_noop() {
+        let mut req = request_with_model("claude-opus-4-7");
+        override_thinking_from_model_name(&mut req);
+        assert!(req.thinking.is_none());
+        assert!(req.output_config.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_opus_4_7_enabled_thinking() {
+        let mut req = request_with_model("claude-opus-4-7");
+        req.max_tokens = 64000;
+        req.thinking = Some(thinking("enabled", 20000));
+        let err = validate_messages_request(&req).expect_err("应拒绝 Opus 4.7 enabled");
+        assert!(err.contains("only supports adaptive thinking"));
+    }
+
+    #[test]
+    fn validate_rejects_legacy_adaptive_thinking() {
+        let mut req = request_with_model("claude-haiku-4-5-20251001");
+        req.max_tokens = 64000;
+        req.thinking = Some(thinking("adaptive", 20000));
+        req.output_config = Some(OutputConfig {
+            effort: "high".to_string(),
+        });
+        let err = validate_messages_request(&req).expect_err("应拒绝 legacy adaptive");
+        assert!(err.contains("does not support adaptive thinking"));
+    }
+
+    #[test]
+    fn validate_rejects_budget_not_less_than_max_tokens() {
+        let mut req = request_with_model("claude-sonnet-4-5-20250929");
+        req.max_tokens = 10000;
+        req.thinking = Some(thinking("enabled", 10000));
+        let err = validate_messages_request(&req).expect_err("应拒绝超预算 thinking");
+        assert!(err.contains("must be less than max_tokens"));
+    }
+
+    #[test]
+    fn validate_accepts_sonnet_4_6_adaptive_medium_effort() {
+        let mut req = request_with_model("claude-sonnet-4-6");
+        req.max_tokens = 64000;
+        req.thinking = Some(thinking("adaptive", 20000));
+        req.output_config = Some(OutputConfig {
+            effort: "medium".to_string(),
+        });
+        validate_messages_request(&req).expect("Sonnet 4.6 adaptive medium 应有效");
+    }
+
+    #[test]
+    fn validate_rejects_invalid_adaptive_effort() {
+        let mut req = request_with_model("claude-sonnet-4-6");
+        req.max_tokens = 64000;
+        req.thinking = Some(thinking("adaptive", 20000));
+        req.output_config = Some(OutputConfig {
+            effort: "xhigh".to_string(),
+        });
+        let err = validate_messages_request(&req).expect_err("Sonnet 4.6 不应支持 xhigh");
+        assert!(err.contains("unsupported output_config.effort"));
+    }
+
+    #[test]
+    fn validate_rejects_max_tokens_above_model_limit() {
+        let mut req = request_with_model("claude-sonnet-4-6");
+        req.max_tokens = 64001;
+        let err = validate_messages_request(&req).expect_err("应拒绝超过模型上限");
+        assert!(err.contains("max_tokens exceeds model limit"));
     }
 
     /// 当 KiroClient 未配置时 `/v1/messages` 必须返回 503，且 body 携带

--- a/src/interface/http/anthropic/models.rs
+++ b/src/interface/http/anthropic/models.rs
@@ -6,13 +6,46 @@
 
 use super::dto::Model;
 
+/// 返回模型的最大输出 token 上限。
+pub fn model_max_tokens(model: &str) -> i32 {
+    let model_lower = model.to_lowercase();
+    if model_lower.contains("opus")
+        && (model_lower.contains("4-7")
+            || model_lower.contains("4.7")
+            || model_lower.contains("4-6")
+            || model_lower.contains("4.6"))
+    {
+        128000
+    } else {
+        64000
+    }
+}
+
 /// Anthropic 兼容协议下当前支持的模型列表（顺序与对外 JSON 一致）。
 ///
 /// 每次调用都会重新构造一份 owned `Vec<Model>`，避免 `Lazy` 的 `Send + Sync` 噪音
 /// 也避免与 axum `Json` 共享所有权时的不必要约束。
-/// 列表本身只有 10 项，重复构造的代价远低于运行时 lock。
+/// 列表本身只有 12 项，重复构造的代价远低于运行时 lock。
 pub fn supported_models() -> Vec<Model> {
     vec![
+        Model {
+            id: "claude-opus-4-7".to_string(),
+            object: "model".to_string(),
+            created: 1777593600, // May 1, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 4.7".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: model_max_tokens("claude-opus-4-7"),
+        },
+        Model {
+            id: "claude-opus-4-7-thinking".to_string(),
+            object: "model".to_string(),
+            created: 1777593600, // May 1, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 4.7 (Thinking)".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: model_max_tokens("claude-opus-4-7-thinking"),
+        },
         Model {
             id: "claude-opus-4-6".to_string(),
             object: "model".to_string(),
@@ -20,7 +53,7 @@ pub fn supported_models() -> Vec<Model> {
             owned_by: "anthropic".to_string(),
             display_name: "Claude Opus 4.6".to_string(),
             model_type: "chat".to_string(),
-            max_tokens: 64000,
+            max_tokens: model_max_tokens("claude-opus-4-6"),
         },
         Model {
             id: "claude-opus-4-6-thinking".to_string(),
@@ -29,7 +62,7 @@ pub fn supported_models() -> Vec<Model> {
             owned_by: "anthropic".to_string(),
             display_name: "Claude Opus 4.6 (Thinking)".to_string(),
             model_type: "chat".to_string(),
-            max_tokens: 64000,
+            max_tokens: model_max_tokens("claude-opus-4-6-thinking"),
         },
         Model {
             id: "claude-sonnet-4-6".to_string(),
@@ -116,6 +149,8 @@ mod tests {
         let models = supported_models();
         let ids: HashSet<&str> = models.iter().map(|m| m.id.as_str()).collect();
         for expected in [
+            "claude-opus-4-7",
+            "claude-opus-4-7-thinking",
             "claude-opus-4-6",
             "claude-opus-4-6-thinking",
             "claude-sonnet-4-6",
@@ -135,20 +170,31 @@ mod tests {
     fn supported_models_preserves_order() {
         let models = supported_models();
         let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
-        assert_eq!(ids[0], "claude-opus-4-6");
-        assert_eq!(ids[2], "claude-sonnet-4-6");
-        assert_eq!(ids[4], "claude-opus-4-5-20251101");
-        assert_eq!(ids[8], "claude-haiku-4-5-20251001");
-        assert_eq!(ids.len(), 10);
+        assert_eq!(ids[0], "claude-opus-4-7");
+        assert_eq!(ids[2], "claude-opus-4-6");
+        assert_eq!(ids[4], "claude-sonnet-4-6");
+        assert_eq!(ids[6], "claude-opus-4-5-20251101");
+        assert_eq!(ids[10], "claude-haiku-4-5-20251001");
+        assert_eq!(ids.len(), 12);
     }
 
     #[test]
-    fn supported_models_all_have_chat_type_and_64k_tokens() {
+    fn supported_models_all_have_chat_type_and_expected_tokens() {
         for m in supported_models() {
             assert_eq!(m.model_type, "chat", "model={}", m.id);
-            assert_eq!(m.max_tokens, 64000, "model={}", m.id);
+            assert_eq!(m.max_tokens, model_max_tokens(&m.id), "model={}", m.id);
             assert_eq!(m.owned_by, "anthropic", "model={}", m.id);
             assert_eq!(m.object, "model", "model={}", m.id);
         }
+    }
+
+    #[test]
+    fn model_max_tokens_marks_opus_4_6_and_4_7_as_128k() {
+        assert_eq!(model_max_tokens("claude-opus-4-7"), 128000);
+        assert_eq!(model_max_tokens("claude-opus-4-7-thinking"), 128000);
+        assert_eq!(model_max_tokens("claude-opus-4-6"), 128000);
+        assert_eq!(model_max_tokens("claude-opus-4-6-thinking"), 128000);
+        assert_eq!(model_max_tokens("claude-sonnet-4-6-thinking"), 64000);
+        assert_eq!(model_max_tokens("claude-haiku-4-5-20251001"), 64000);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,13 +257,40 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     let pool_for_shutdown = pool.clone();
-    // graceful shutdown：信号触发后等所有连接关闭再返回；用 timeout 兜底防止
-    // 长 SSE 连接卡住 flush_stats（30s 上限）
-    let serve = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
-    match tokio::time::timeout(std::time::Duration::from_secs(30), serve).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => tracing::error!("HTTP 服务异常退出: {}", e),
-        Err(_) => tracing::warn!("graceful shutdown 超时 30s，强制退出（仍会 flush_stats）"),
+
+    // graceful shutdown 的正确形态：
+    //   1. serve 平时无 timeout 限制，持续运行；
+    //   2. 收到信号后进入 drain 阶段；
+    //   3. drain 最多等 30 秒，超时则强制退出（防止长 SSE 连接卡住 flush_stats）。
+    //
+    // 早期版本用 `tokio::time::timeout(30s, serve)` 包住整个 serve，相当于给
+    // 服务器本身设了 30 秒硬上限，没有信号也会强退。这里用一个 oneshot 标记
+    // "信号已触达"的时间点，把 30 秒窗口限制在 drain 阶段。
+    let (signaled_tx, signaled_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown_and_mark = async move {
+        shutdown_signal().await;
+        // 信号已触达：通知 watchdog 启动 30 秒 drain 计时
+        let _ = signaled_tx.send(());
+    };
+    let drain_watchdog = async move {
+        // 信号未触达时保持挂起（drain_watchdog 永远不 resolve），select! 由 serve 那边驱动
+        if signaled_rx.await.is_err() {
+            std::future::pending::<()>().await;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    };
+
+    let serve = axum::serve(listener, app).with_graceful_shutdown(shutdown_and_mark);
+
+    tokio::select! {
+        res = serve => {
+            if let Err(e) = res {
+                tracing::error!("HTTP 服务异常退出: {}", e);
+            }
+        }
+        _ = drain_watchdog => {
+            tracing::warn!("graceful shutdown drain 超时 30s，强制退出（仍会 flush_stats）");
+        }
     }
 
     // 进程退出前显式 flush stats，避免最后一窗口的统计因未到 30s debounce 丢失

--- a/src/service/conversation/converter.rs
+++ b/src/service/conversation/converter.rs
@@ -34,6 +34,7 @@ Complete all chunked operations without commentary.";
 /// 按照用户要求：
 /// - sonnet 4.6/4-6 → claude-sonnet-4.6
 /// - 其他 sonnet → claude-sonnet-4.5
+/// - opus 4.7/4-7 → claude-opus-4.7
 /// - opus 4.5/4-5 → claude-opus-4.5
 /// - 其他 opus → claude-opus-4.6
 /// - 所有 haiku → claude-haiku-4.5
@@ -49,6 +50,8 @@ pub fn map_model(model: &str) -> Option<String> {
     } else if model_lower.contains("opus") {
         if model_lower.contains("4-5") || model_lower.contains("4.5") {
             Some("claude-opus-4.5".to_string())
+        } else if model_lower.contains("4-7") || model_lower.contains("4.7") {
+            Some("claude-opus-4.7".to_string())
         } else {
             Some("claude-opus-4.6".to_string())
         }
@@ -62,10 +65,17 @@ pub fn map_model(model: &str) -> Option<String> {
 /// 根据模型名称返回对应的上下文窗口大小
 ///
 /// 复用 `map_model` 的映射逻辑，确保窗口大小判断与模型映射一致。
-/// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
+/// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文；
+/// Opus 4.7 发布即 1M 上下文。
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
-        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" => 1_000_000,
+        Some(mapped)
+            if mapped == "claude-sonnet-4.6"
+                || mapped == "claude-opus-4.6"
+                || mapped == "claude-opus-4.7" =>
+        {
+            1_000_000
+        }
         _ => 200_000,
     }
 }
@@ -667,6 +677,35 @@ mod tests {
     }
 
     #[test]
+    fn test_map_model_opus_4_7() {
+        // 新增：opus 4.7 映射到 claude-opus-4.7
+        assert_eq!(
+            map_model("claude-opus-4-7"),
+            Some("claude-opus-4.7".to_string())
+        );
+        assert_eq!(
+            map_model("claude-opus-4.7"),
+            Some("claude-opus-4.7".to_string())
+        );
+    }
+
+    #[test]
+    fn test_map_model_thinking_suffix_opus_4_7() {
+        // thinking 后缀不应影响 opus 4.7 模型映射
+        let result = map_model("claude-opus-4-7-thinking");
+        assert_eq!(result, Some("claude-opus-4.7".to_string()));
+    }
+
+    #[test]
+    fn test_context_window_opus_4_7_is_1m() {
+        assert_eq!(get_context_window_size("claude-opus-4-7"), 1_000_000);
+        assert_eq!(
+            get_context_window_size("claude-opus-4-7-thinking"),
+            1_000_000
+        );
+    }
+
+    #[test]
     fn test_map_model_thinking_suffix_haiku() {
         // thinking 后缀不应影响 haiku 模型映射
         let result = map_model("claude-haiku-4-5-20251001-thinking");
@@ -689,6 +728,37 @@ mod tests {
             metadata: None,
         };
         assert_eq!(determine_chat_trigger_type(&req), "MANUAL");
+    }
+
+    #[test]
+    fn test_adaptive_thinking_prefix_uses_client_effort() {
+        use crate::interface::http::anthropic::dto::{OutputConfig, Thinking};
+
+        let req = MessagesRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 64000,
+            messages: vec![],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: Some(Thinking {
+                thinking_type: "adaptive".to_string(),
+                budget_tokens: 20000,
+                display: None,
+            }),
+            output_config: Some(OutputConfig {
+                effort: "medium".to_string(),
+            }),
+            metadata: None,
+        };
+
+        assert_eq!(
+            generate_thinking_prefix(&req).as_deref(),
+            Some(
+                "<thinking_mode>adaptive</thinking_mode><thinking_effort>medium</thinking_effort>"
+            )
+        );
     }
 
     // 工具相关函数级单测（collect_history_tool_names / create_placeholder_tool /

--- a/src/service/credential_pool/pool.rs
+++ b/src/service/credential_pool/pool.rs
@@ -808,7 +808,7 @@ impl CredentialPool {
         Ok(())
     }
 
-    /// 查询使用额度（必要时刷新 token，调上游 q.{region}.amazonaws.com/getUsageLimits）
+    /// 查询使用额度（必要时刷新 token，调上游 usage limits 端点）
     pub async fn get_usage_limits_for(
         &self,
         id: u64,
@@ -879,8 +879,35 @@ impl CredentialPool {
         cred: &Credential,
         token: &str,
     ) -> Result<UsageLimitsResponse, AdminPoolError> {
+        let request = self.build_usage_limits_request(cred, token)?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| AdminPoolError::Network(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            // 截断 body，避免大响应回显放大 + 限制错误链中的敏感细节泄漏
+            let body = truncate_upstream_body(&body, 512);
+            return Err(AdminPoolError::UpstreamHttp {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        let usage: UsageLimitsResponse = response
+            .json()
+            .await
+            .map_err(|e| AdminPoolError::Network(e.to_string()))?;
+        Ok(usage)
+    }
+
+    fn build_usage_limits_request(
+        &self,
+        cred: &Credential,
+        token: &str,
+    ) -> Result<reqwest::RequestBuilder, AdminPoolError> {
         let region = cred.effective_api_region(&self.config);
-        let host = format!("q.{region}.amazonaws.com");
+        let host = format!("management.{region}.kiro.dev");
         let machine_id = self.resolver.resolve(cred, &self.config);
         let kiro_version = &self.config.kiro.kiro_version;
         let os_name = &self.config.kiro.system_version;
@@ -915,25 +942,7 @@ impl CredentialPool {
             req = req.header("tokentype", "API_KEY");
         }
 
-        let response = req
-            .send()
-            .await
-            .map_err(|e| AdminPoolError::Network(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            // 截断 body，避免大响应回显放大 + 限制错误链中的敏感细节泄漏
-            let body = truncate_upstream_body(&body, 512);
-            return Err(AdminPoolError::UpstreamHttp {
-                status: status.as_u16(),
-                body,
-            });
-        }
-        let usage: UsageLimitsResponse = response
-            .json()
-            .await
-            .map_err(|e| AdminPoolError::Network(e.to_string()))?;
-        Ok(usage)
+        Ok(req)
     }
 }
 
@@ -1047,6 +1056,49 @@ mod tests {
 
     fn far_future_expires_at() -> String {
         (Utc::now() + Duration::days(7)).to_rfc3339()
+    }
+
+    #[test]
+    fn fetch_usage_limits_uses_management_endpoint_host() {
+        let file = Arc::new(CredentialsFileStore::new(None));
+        let config = Config::default();
+        let config = Arc::new(config);
+        let resolver = Arc::new(MachineIdResolver::new());
+        let (store, _) = CredentialStore::load(file, config.clone(), resolver.clone()).unwrap();
+        let pool = CredentialPool::new(
+            Arc::new(store),
+            Arc::new(CredentialState::new()),
+            Arc::new(CredentialStats::new()),
+            None,
+            config,
+            resolver,
+        );
+        let cred = Credential {
+            auth_method: Some("api_key".to_string()),
+            kiro_api_key: Some("test-api-key".to_string()),
+            ..Default::default()
+        };
+
+        let request = pool
+            .build_usage_limits_request(&cred, "test-token")
+            .expect("build usage request")
+            .build()
+            .expect("finalize usage request");
+        assert_eq!(
+            request.url().as_str(),
+            "https://management.us-east-1.kiro.dev/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST"
+        );
+        assert_eq!(
+            request.headers().get("host").and_then(|v| v.to_str().ok()),
+            Some("management.us-east-1.kiro.dev")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("tokentype")
+                .and_then(|v| v.to_str().ok()),
+            Some("API_KEY")
+        );
     }
 
     /// 测试用 refresher：计数自增；可设置 sleep 模拟延迟


### PR DESCRIPTION
---

## `ecb8214` — fix: align Claude thinking model metadata

主题:接入 Claude Opus 4.7,并把 thinking 配置逻辑从"强制覆写"改成"补齐 + 校验",同时捎带修了一个 graceful shutdown 的 bug。

**1. 新增 Opus 4.7 模型支持**
- `src/interface/http/anthropic/models.rs`:`supported_models()` 新增 `claude-opus-4-7` 和 `claude-opus-4-7-thinking`(列表从 10 条 → 12 条)。抽出 `model_max_tokens(model)` 函数:Opus 4.6 / 4.7 系列返回 `128000`,其余 `64000`。
- `src/service/conversation/converter.rs`:`map_model` 新增 `opus 4.7/4-7 → claude-opus-4.7` 映射;`get_context_window_size` 给 `claude-opus-4.7` 也赋 1M 上下文(Kiro 的 Opus 4.7 发布即 1M)。

**2. Thinking 配置重构:覆写 → 补齐**
- `src/interface/http/anthropic/dto.rs`
  - 移除硬编码的 `MAX_BUDGET_TOKENS = 24576` 和它绑定的 `deserialize_budget_tokens`(之前会静默把客户端传入的 `budget_tokens` 截到 24K,现在放行)。
  - `Thinking` 新增 `display: Option<String>` 字段。
- `src/interface/http/anthropic/handlers.rs`
  - 新增一组模型能力判定函数:`model_is_opus_4_7 / 4_6 / sonnet_4_6`、`model_supports_adaptive_thinking`、`validate_effort_for_model`、`default_alias_budget`。
  - 把 `override_thinking_from_model_name` 从"固定写 `budget_tokens=20000`"改成"优先保留客户端传入值",并且只有当客户端没传 `output_config` 时才补默认 `effort=high`。
  - 新增 `validate_messages_request` + `validate_thinking_config`,在请求进入正式处理前校验:
    - `max_tokens > 0` 且不超过 `model_max_tokens` 上限
    - `thinking.display` 仅允许 `omitted / summarized`
    - `enabled` 分支:Opus 4.7 拒绝使用;`budget_tokens > 0` 且 `< max_tokens`
    - `adaptive` 分支:模型必须支持;`effort` 按模型分级校验(`low/medium/high` 通用,`max` 仅 adaptive 模型,`xhigh` 仅 Opus 4.7)
  - 失败走 `400 invalid_request_error`。
- 新增 11 个单元测试覆盖 override 与 validate 的各个分支。

**3. Graceful shutdown 修复**
- `src/main.rs`:之前 `tokio::time::timeout(30s, serve)` 实际上是给整个服务器硬性加了 30 秒上限,没有信号也会强退(进程被 watchdog 杀死)。改为用 oneshot 标记信号时刻,用 `select!` 配合 `drain_watchdog`,让 30 秒窗口只约束到 drain 阶段。

**4. README**
- Thinking 示例更新成 `claude-sonnet-4-6 / max_tokens 64000 / type: "adaptive"`。
- 模型映射表补 `sonnet 4.6` 和 `opus 4.7` 条目。
- 说明 `-thinking` 便捷名会自动补齐 `adaptive + effort=high`。

---

## `5ed04ae` — fix(endpoint): use Kiro runtime hosts

主题:Kiro 把上游迁出了 AWS 域名,全部请求地址切到 `*.kiro.dev`。

**1. IDE 端点 host 切换**
- `src/infra/endpoint/ide.rs`
  - `q.{region}.amazonaws.com` → `runtime.{region}.kiro.dev`
  - `api_url`:`.../generateAssistantResponse`
  - `mcp_url`:`.../mcp`
  - `host(&self, ctx)` 随之更新
- 注意:配置层的 `defaultEndpoint: "ide"` 名称**保留不变**,只是实际出站地址换了。
- 测试重写:用真实的 `Credential / Config / RequestContext` 覆盖 `name()` / `api_url` / `mcp_url` / `credential.api_region` 覆盖 config 区域等场景,并保留 `inject_profile_arn` 的所有原有测试。

**2. Usage limits 端点 host 切换**
- `src/service/credential_pool/pool.rs`
  - `q.{region}.amazonaws.com` → `management.{region}.kiro.dev`(注意这个走的是 `management` 子域,与 IDE 的 `runtime` 不同)
  - `fetch_usage_limits` 被拆成两部分:`build_usage_limits_request`(纯组装 `RequestBuilder`,可测)+ `fetch_usage_limits`(只管 `send().await` 和响应处理)
  - 新增测试 `fetch_usage_limits_uses_management_endpoint_host`,验证最终 URL、Host 头、以及 `tokentype=API_KEY` 头

**3. README**
- 配置示例补 `"defaultEndpoint": "ide"`
- 新增 "Kiro 端点" 段落,列出三个实际请求地址并说明 `ide` 名称保留用于兼容