### PR TITLE
feat: add opus 4.7 support, reset-stats API & Docker build fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ Cargo.lock
 # Node.js dependencies and build artifacts
 admin-ui/node_modules/
 admin-ui/dist/
-admin-ui/pnpm-lock.yaml
 admin-ui/tsconfig.tsbuildinfo
 admin-ui/.vite/
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  OWNER_LC: ${{ github.repository_owner }}
+
 jobs:
   pre-check:
     runs-on: ubuntu-latest
@@ -60,6 +63,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Lowercase owner
+        id: owner
+        run: echo "name=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Determine version
         id: version
         run: |
@@ -94,7 +101,7 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           provenance: false
-          tags: ghcr.io/${{ github.repository_owner }}/kiro-rs:${{ steps.version.outputs.version }}-${{ matrix.arch }}
+          tags: ghcr.io/${{ steps.owner.outputs.name }}/kiro-rs:${{ steps.version.outputs.version }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.description=Kiro.rs Docker Image
@@ -103,6 +110,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Lowercase owner
+        id: owner
+        run: echo "name=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -114,7 +125,7 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           IS_BETA="${{ needs.build.outputs.is_beta }}"
-          IMAGE="ghcr.io/${{ github.repository_owner }}/kiro-rs"
+          IMAGE="ghcr.io/${{ steps.owner.outputs.name }}/kiro-rs"
 
           # Create manifest for version tag
           docker manifest create ${IMAGE}:${VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:22-alpine AS frontend-builder
 
+RUN npm install -g pnpm@9
+
 WORKDIR /app/admin-ui
-COPY admin-ui/package.json ./
-RUN npm install -g pnpm && pnpm install
+COPY admin-ui/package.json admin-ui/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 COPY admin-ui ./
 RUN pnpm build
 

--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -93,6 +93,18 @@ export async function deleteCredential(id: number): Promise<SuccessResponse> {
   return data
 }
 
+// 重置单个凭据的成功次数
+export async function resetSuccessCount(id: number): Promise<SuccessResponse> {
+  const { data } = await api.post<SuccessResponse>(`/credentials/${id}/reset-stats`)
+  return data
+}
+
+// 重置所有凭据的成功次数
+export async function resetAllSuccessCount(): Promise<SuccessResponse> {
+  const { data } = await api.post<SuccessResponse>('/credentials/reset-stats')
+  return data
+}
+
 // 获取负载均衡模式
 export async function getLoadBalancingMode(): Promise<{ mode: 'priority' | 'balanced' }> {
   const { data } = await api.get<{ mode: 'priority' | 'balanced' }>('/config/load-balancing')

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -22,6 +22,7 @@ import {
   useResetFailure,
   useDeleteCredential,
   useForceRefreshToken,
+  useResetSuccessCount,
 } from '@/hooks/use-credentials'
 
 interface CredentialCardProps {
@@ -66,6 +67,7 @@ export function CredentialCard({
   const resetFailure = useResetFailure()
   const deleteCredential = useDeleteCredential()
   const forceRefresh = useForceRefreshToken()
+  const resetSuccess = useResetSuccessCount()
 
   const handleToggleDisabled = () => {
     setDisabled.mutate(
@@ -119,6 +121,17 @@ export function CredentialCard({
       },
       onError: (err) => {
         toast.error('刷新失败: ' + (err as Error).message)
+      },
+    })
+  }
+
+  const handleResetSuccess = () => {
+    resetSuccess.mutate(credential.id, {
+      onSuccess: (res) => {
+        toast.success(res.message)
+      },
+      onError: (err) => {
+        toast.error('重置失败: ' + (err as Error).message)
       },
     })
   }
@@ -252,7 +265,14 @@ export function CredentialCard({
             </div>
             <div>
               <span className="text-muted-foreground">成功次数：</span>
-              <span className="font-medium">{credential.successCount}</span>
+              <span
+                className="font-medium cursor-pointer hover:underline"
+                onClick={handleResetSuccess}
+                title="点击重置成功次数"
+              >
+                {credential.successCount}
+                <span className="text-xs text-muted-foreground ml-1">(点击重置)</span>
+              </span>
             </div>
             <div className="col-span-2">
               <span className="text-muted-foreground">最后调用：</span>

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -12,7 +12,7 @@ import { AddCredentialDialog } from '@/components/add-credential-dialog'
 import { BatchImportDialog } from '@/components/batch-import-dialog'
 import { KamImportDialog } from '@/components/kam-import-dialog'
 import { BatchVerifyDialog, type VerifyResult } from '@/components/batch-verify-dialog'
-import { useCredentials, useDeleteCredential, useResetFailure, useLoadBalancingMode, useSetLoadBalancingMode } from '@/hooks/use-credentials'
+import { useCredentials, useDeleteCredential, useResetFailure, useLoadBalancingMode, useSetLoadBalancingMode, useResetAllSuccessCount } from '@/hooks/use-credentials'
 import { getCredentialBalance, forceRefreshToken } from '@/api/credentials'
 import { extractErrorMessage } from '@/lib/utils'
 import type { BalanceResponse } from '@/types/api'
@@ -54,6 +54,7 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const { mutate: resetFailure } = useResetFailure()
   const { data: loadBalancingData, isLoading: isLoadingMode } = useLoadBalancingMode()
   const { mutate: setLoadBalancingMode, isPending: isSettingMode } = useSetLoadBalancingMode()
+  const resetAllSuccess = useResetAllSuccessCount()
 
   // 计算分页
   const totalPages = Math.ceil((data?.credentials.length || 0) / itemsPerPage)
@@ -656,6 +657,22 @@ export function Dashboard({ onLogout }: DashboardProps) {
                 <Button onClick={() => setVerifyDialogOpen(true)} size="sm" variant="secondary">
                   <CheckCircle2 className="h-4 w-4 mr-2 animate-spin" />
                   验活中... {verifyProgress.current}/{verifyProgress.total}
+                </Button>
+              )}
+              {data?.credentials && data.credentials.length > 0 && (
+                <Button
+                  onClick={() => {
+                    resetAllSuccess.mutate(undefined, {
+                      onSuccess: (res) => toast.success(res.message),
+                      onError: (err) => toast.error('重置失败: ' + (err as Error).message),
+                    })
+                  }}
+                  size="sm"
+                  variant="outline"
+                  disabled={resetAllSuccess.isPending}
+                >
+                  <RotateCcw className={`h-4 w-4 mr-2 ${resetAllSuccess.isPending ? 'animate-spin' : ''}`} />
+                  重置成功次数
                 </Button>
               )}
               {data?.credentials && data.credentials.length > 0 && (

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -10,6 +10,8 @@ import {
   deleteCredential,
   getLoadBalancingMode,
   setLoadBalancingMode,
+  resetSuccessCount,
+  resetAllSuccessCount,
 } from '@/api/credentials'
 import type { AddCredentialRequest } from '@/types/api'
 
@@ -94,6 +96,28 @@ export function useDeleteCredential() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => deleteCredential(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
+  })
+}
+
+// 重置单个凭据的成功次数
+export function useResetSuccessCount() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => resetSuccessCount(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
+  })
+}
+
+// 重置所有凭据的成功次数
+export function useResetAllSuccessCount() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => resetAllSuccessCount(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['credentials'] })
     },

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -122,6 +122,35 @@ pub async fn force_refresh_token(
     }
 }
 
+/// POST /api/admin/credentials/reset-stats
+/// 重置所有凭据的 success_count
+pub async fn reset_all_success_count(State(state): State<AdminState>) -> impl IntoResponse {
+    match state.service.reset_success_count(None) {
+        Ok(count) => Json(SuccessResponse::new(format!(
+            "已重置 {} 个凭据的 success_count",
+            count
+        )))
+        .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// POST /api/admin/credentials/:id/reset-stats
+/// 重置指定凭据的 success_count
+pub async fn reset_success_count(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+) -> impl IntoResponse {
+    match state.service.reset_success_count(Some(id)) {
+        Ok(_) => Json(SuccessResponse::new(format!(
+            "凭据 #{} success_count 已重置",
+            id
+        )))
+        .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
 /// GET /api/admin/config/load-balancing
 /// 获取负载均衡模式
 pub async fn get_load_balancing_mode(State(state): State<AdminState>) -> impl IntoResponse {

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -8,8 +8,9 @@ use axum::{
 use super::{
     handlers::{
         add_credential, delete_credential, force_refresh_token, get_all_credentials,
-        get_credential_balance, get_load_balancing_mode, reset_failure_count,
-        set_credential_disabled, set_credential_priority, set_load_balancing_mode,
+        get_credential_balance, get_load_balancing_mode, reset_all_success_count,
+        reset_failure_count, reset_success_count, set_credential_disabled,
+        set_credential_priority, set_load_balancing_mode,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -42,6 +43,8 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))
         .route("/credentials/{id}/reset", post(reset_failure_count))
+        .route("/credentials/{id}/reset-stats", post(reset_success_count))
+        .route("/credentials/reset-stats", post(reset_all_success_count))
         .route("/credentials/{id}/refresh", post(force_refresh_token))
         .route("/credentials/{id}/balance", get(get_credential_balance))
         .route(

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -132,6 +132,12 @@ impl AdminService {
             .map_err(|e| self.classify_error(e, id))
     }
 
+    pub fn reset_success_count(&self, id: Option<u64>) -> Result<u32, AdminServiceError> {
+        self.token_manager
+            .reset_success_count(id)
+            .map_err(|e| self.classify_error(e, id.unwrap_or(0)))
+    }
+
     /// 获取凭据余额（带缓存）
     pub async fn get_balance(&self, id: u64) -> Result<BalanceResponse, AdminServiceError> {
         // 先查缓存

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -93,7 +93,9 @@ pub fn map_model(model: &str) -> Option<String> {
             Some("claude-sonnet-4.5".to_string())
         }
     } else if model_lower.contains("opus") {
-        if model_lower.contains("4-5") || model_lower.contains("4.5") {
+        if model_lower.contains("4-7") || model_lower.contains("4.7") {
+            Some("claude-opus-4.7".to_string())
+        } else if model_lower.contains("4-5") || model_lower.contains("4.5") {
             Some("claude-opus-4.5".to_string())
         } else {
             Some("claude-opus-4.6".to_string())
@@ -111,7 +113,7 @@ pub fn map_model(model: &str) -> Option<String> {
 /// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
-        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" => 1_000_000,
+        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" => 1_000_000,
         _ => 200_000,
     }
 }

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1529,6 +1529,31 @@ impl MultiTokenManager {
         Ok(())
     }
 
+    pub fn reset_success_count(&self, id: Option<u64>) -> anyhow::Result<u32> {
+        let mut count = 0u32;
+        {
+            let mut entries = self.entries.lock();
+            match id {
+                Some(target_id) => {
+                    let entry = entries
+                        .iter_mut()
+                        .find(|e| e.id == target_id)
+                        .ok_or_else(|| anyhow::anyhow!("凭据不存在: {}", target_id))?;
+                    entry.success_count = 0;
+                    count = 1;
+                }
+                None => {
+                    for entry in entries.iter_mut() {
+                        entry.success_count = 0;
+                        count += 1;
+                    }
+                }
+            }
+        }
+        self.save_stats();
+        Ok(count)
+    }
+
     /// 获取指定凭据的使用额度（Admin API）
     pub async fn get_usage_limits_for(&self, id: u64) -> anyhow::Result<UsageLimitsResponse> {
         let credentials = {


### PR DESCRIPTION
## Summary
- **feat: add claude-opus-4.7 model mapping** — map `claude-opus-4-7` / `claude-opus-4.7` to Kiro model ID `claude-opus-4.7` with 1M context window
- **feat: add reset success_count API endpoints** — `POST /credentials/{id}/reset-stats` and `POST /credentials/reset-stats` to reset credential success counters
- **fix: Docker build** — lowercase repository owner in ghcr.io tags, copy `pnpm-lock.yaml` into build context, pin pnpm@9

## Test plan
- [ ] `cargo test` passes (map_model tests cover opus 4.7 mapping)
- [ ] Verify `claude-opus-4-7` requests are correctly mapped to `claude-opus-4.7` upstream
- [ ] Verify reset-stats endpoints work via admin API
- [ ] Docker image builds successfully on GitHub Actions