### PR TITLE
feat(ci): 在 tag 发布时上传归档至 GitHub Releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,6 +122,36 @@ jobs:
       - name: Build app
         run: cargo build --release --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--no-default-features' || '' }}
 
+      - name: Package archive (Unix)
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        run: |
+          ARCHIVE_NAME="kiro-rs-${{ steps.version.outputs.version }}-${{ matrix.name }}"
+          STAGING_DIR="${ARCHIVE_NAME}"
+          mkdir -p "${STAGING_DIR}"
+          cp "target/${{ matrix.target }}/release/kiro-rs" "${STAGING_DIR}/"
+          cp README.md LICENSE "${STAGING_DIR}/" 2>/dev/null || true
+          tar -czf "${ARCHIVE_NAME}.tar.gz" "${STAGING_DIR}"
+          shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
+          echo "asset_path=${ARCHIVE_NAME}.tar.gz" >> $GITHUB_ENV
+          echo "asset_sha=${ARCHIVE_NAME}.tar.gz.sha256" >> $GITHUB_ENV
+
+      - name: Package archive (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $archiveName = "kiro-rs-${{ steps.version.outputs.version }}-${{ matrix.name }}"
+          $stagingDir = $archiveName
+          New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/kiro-rs.exe" -Destination $stagingDir
+          if (Test-Path README.md) { Copy-Item README.md -Destination $stagingDir }
+          if (Test-Path LICENSE) { Copy-Item LICENSE -Destination $stagingDir }
+          Compress-Archive -Path $stagingDir -DestinationPath "$archiveName.zip"
+          $hash = Get-FileHash "$archiveName.zip" -Algorithm SHA256
+          "$($hash.Hash.ToLower())  $archiveName.zip" | Out-File -Encoding ascii "$archiveName.zip.sha256"
+          "asset_path=$archiveName.zip" | Out-File -Append -Encoding ascii $env:GITHUB_ENV
+          "asset_sha=$archiveName.zip.sha256" | Out-File -Append -Encoding ascii $env:GITHUB_ENV
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -129,5 +159,37 @@ jobs:
           if-no-files-found: error
           compression-level: 6
           path: |
-            target/${{ matrix.target }}/release/kiro-rs
-            target/${{ matrix.target }}/release/kiro-rs.exe
+            ${{ env.asset_path }}
+            ${{ env.asset_sha }}
+
+  release:
+    name: Publish Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) -exec cp {} release-assets/ \;
+          ls -la release-assets
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            release-assets/*


### PR DESCRIPTION
## 变更说明

更新 `.github/workflows/build.yaml`，在推送 `v*` tag 时自动创建 GitHub Release 并上传跨平台二进制归档。

## 主要改动

- **打包步骤**：每个 target 构建后将二进制 + `README.md` + `LICENSE` 打包
  - Unix（macOS/Linux）：`.tar.gz`
  - Windows：`.zip`
  - 附带 `.sha256` 校验文件
- **新增 `release` job**
  - 仅在 `refs/tags/v*` 时触发
  - 权限 `contents: write`
  - 下载所有平台 artifacts → 扁平化 → 通过 `softprops/action-gh-release@v2` 创建 Release
  - 自动生成 release notes
  - 上传 7 个平台的归档（macOS arm64/x64、Windows x64、Linux gnu/musl × x64/arm64）

## 触发行为

| 触发 | 构建 artifacts | 发布 Release |
| --- | --- | --- |
| push master | ✅ beta | ❌ |
| push v* tag | ✅ 正式版本 | ✅ |
| workflow_dispatch | ✅ | ❌ |

## 使用

```sh
git tag 2026.05.14
git push origin 2026.05.14
```