### PR TITLE
feat(cli): 新增 CLI endpoint，修复工具 schema 兼容性问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ docker-compose up
 | `adminApiKey` | string | - | Admin API 密钥，配置后启用凭据管理 API 和 Web 管理界面 |
 | `loadBalancingMode` | string | `priority` | 负载均衡模式：`priority`（按优先级）或 `balanced`（均衡分配） |
 | `extractThinking` | boolean | `true` | 非流式响应的 thinking 块提取。启用后 `<thinking>` 标签会被解析为独立的 `thinking` 内容块 |
-| `defaultEndpoint` | string | `ide` | 默认 Kiro 端点。凭据未显式指定 `endpoint` 时使用。当前支持：`ide` |
+| `defaultEndpoint` | string | `ide` | 默认 Kiro 端点。凭据未显式指定 `endpoint` 时使用。可选值：`ide`（Kiro IDE）、`cli`（Amazon Q for CLI，适用于 `ksk_` 前缀的 API Key） |
 
 完整配置示例：
 
@@ -245,11 +245,13 @@ docker-compose up
 | `proxyUrl`     | string | 凭据级代理 URL（可选，特殊值 `direct` 表示不使用代理）       |
 | `proxyUsername`| string | 凭据级代理用户名（可选）                                |
 | `proxyPassword`| string | 凭据级代理密码（可选）                                 |
-| `endpoint`     | string | 凭据级端点名称（可选，未配置时使用 `config.defaultEndpoint`）|
+| `endpoint`     | string | 凭据级端点名称（可选，未配置时使用 `config.defaultEndpoint`）。可选值：`ide`、`cli` |
+| `kiroApiKey`   | string | Kiro API Key（`ksk_` 前缀，仅 `authMethod: "api_key"` 时使用） |
 
 说明：
 - IdC / Builder-ID / IAM 在本项目里属于同一种登录方式，配置时统一使用 `authMethod: "idc"`
 - 为兼容旧配置，`builder-id` / `iam` 仍可被识别，但会按 `idc` 处理
+- **`ksk_` 前缀的 API Key 凭据必须将 `endpoint` 设为 `cli`**（或将 `config.defaultEndpoint` 设为 `cli`），否则请求会因协议不匹配而失败
 
 #### 单凭据格式（旧格式，向后兼容）
 

--- a/credentials.example.apikey.json
+++ b/credentials.example.apikey.json
@@ -1,4 +1,5 @@
 {
     "kiroApiKey": "ksk_your_api_key_here",
-    "authMethod": "api_key"
+    "authMethod": "api_key",
+    "endpoint": "cli"
 }

--- a/credentials.example.multiple.json
+++ b/credentials.example.multiple.json
@@ -1,11 +1,17 @@
 [
   {
+    "kiroApiKey": "ksk_your_api_key_here",
+    "authMethod": "api_key",
+    "endpoint": "cli",
+    "priority": 0
+  },
+  {
     "refreshToken": "xxxxxxxxxxxxxxxxxxxx",
     "expiresAt": "2025-12-31T02:32:45.144Z",
     "authMethod": "social",
     "machineId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "priority": 0,
-    "endpoint": "ide"
+    "endpoint": "ide",
+    "priority": 1
   },
   {
     "refreshToken": "yyyyyyyyyyyyyyyyyyyy",
@@ -15,7 +21,8 @@
     "clientSecret": "xxxxxxxxx",
     "region": "us-east-2",
     "machineId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "priority": 1,
+    "endpoint": "ide",
+    "priority": 2,
     "disabled": true
   }
 ]

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -18,9 +18,11 @@ use crate::kiro::model::requests::tool::{
 use super::types::{ContentBlock, MessagesRequest};
 
 /// 规范化 JSON Schema，修复 MCP 工具定义中常见的类型问题
+/// 规范化 JSON Schema，修复工具定义中常见的类型问题
 ///
-/// Claude Code / MCP 工具定义偶尔会出现 `required: null`、`properties: null` 等，
-/// 导致上游返回 400 "Improperly formed request"。
+/// 问题根源：Claude Code / MCP 工具定义使用 JSON Schema Draft 2020-12 语法（`$schema`、
+/// `exclusiveMinimum` 为数字等），kiro CLI endpoint 仅接受 Draft 07 格式，
+/// 不合规字段会导致 ValidationException "Improperly formed request."。
 fn normalize_json_schema(schema: serde_json::Value) -> serde_json::Value {
     let serde_json::Value::Object(mut obj) = schema else {
         return serde_json::json!({
@@ -31,14 +33,23 @@ fn normalize_json_schema(schema: serde_json::Value) -> serde_json::Value {
         });
     };
 
+    // 移除 $schema（kiro API 不接受此字段，且 Draft 2020-12 声明会触发校验失败）
+    obj.remove("$schema");
+
     // type（必须是字符串）
     if !obj.get("type").and_then(|v| v.as_str()).is_some_and(|s| !s.is_empty()) {
         obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
     }
 
-    // properties（必须是 object）
-    match obj.get("properties") {
-        Some(serde_json::Value::Object(_)) => {}
+    // properties（必须是 object）；递归规范化每个 property 的子 schema
+    match obj.remove("properties") {
+        Some(serde_json::Value::Object(props)) => {
+            let normalized: serde_json::Map<String, serde_json::Value> = props
+                .into_iter()
+                .map(|(k, v)| (k, normalize_property_schema(v)))
+                .collect();
+            obj.insert("properties".to_string(), serde_json::Value::Object(normalized));
+        }
         _ => { obj.insert("properties".to_string(), serde_json::Value::Object(serde_json::Map::new())); }
     }
 
@@ -57,6 +68,53 @@ fn normalize_json_schema(schema: serde_json::Value) -> serde_json::Value {
     match obj.get("additionalProperties") {
         Some(serde_json::Value::Bool(_)) | Some(serde_json::Value::Object(_)) => {}
         _ => { obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(true)); }
+    }
+
+    serde_json::Value::Object(obj)
+}
+
+/// 规范化 property 级别的子 schema（非顶层 inputSchema）
+///
+/// 处理 Draft 2020-12 特有字段，使其兼容 Draft 07：
+/// - 移除 `$schema`
+/// - `exclusiveMinimum`/`exclusiveMaximum` 为数字时（Draft 2019-09+）移除（Draft 07 仅支持 bool）
+/// - `maximum`/`minimum` 超过 i32 范围时移除（部分 AWS validator 不接受超大整数约束）
+fn normalize_property_schema(schema: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(mut obj) = schema else {
+        return schema;
+    };
+
+    obj.remove("$schema");
+
+    // exclusiveMinimum/exclusiveMaximum：Draft 2019-09+ 为数字，Draft 07 为 bool；移除数字形式
+    if obj.get("exclusiveMinimum").and_then(|v| v.as_f64()).is_some() {
+        obj.remove("exclusiveMinimum");
+    }
+    if obj.get("exclusiveMaximum").and_then(|v| v.as_f64()).is_some() {
+        obj.remove("exclusiveMaximum");
+    }
+
+    // maximum/minimum 超过 i64::MAX 或为 JavaScript MAX_SAFE_INTEGER (9007199254740991) 时移除
+    for key in &["maximum", "minimum"] {
+        if let Some(v) = obj.get(*key).and_then(|v| v.as_f64()) {
+            if v > 2_147_483_647.0 || v < -2_147_483_648.0 {
+                obj.remove(*key);
+            }
+        }
+    }
+
+    // 递归处理嵌套 properties
+    if let Some(serde_json::Value::Object(props)) = obj.remove("properties") {
+        let normalized: serde_json::Map<String, serde_json::Value> = props
+            .into_iter()
+            .map(|(k, v)| (k, normalize_property_schema(v)))
+            .collect();
+        obj.insert("properties".to_string(), serde_json::Value::Object(normalized));
+    }
+
+    // 递归处理 items（数组元素 schema）
+    if let Some(items) = obj.remove("items") {
+        obj.insert("items".to_string(), normalize_property_schema(items));
     }
 
     serde_json::Value::Object(obj)
@@ -595,6 +653,13 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>, tool_name_map: &mut Ha
                 description.push('\n');
                 description.push_str(suffix);
             }
+
+            // kiro API 不接受空描述，填充占位符
+            let description = if description.trim().is_empty() {
+                t.name.clone()
+            } else {
+                description
+            };
 
             // 限制描述长度为 10000 字符（安全截断 UTF-8，单次遍历）
             let description = match description.char_indices().nth(10000) {

--- a/src/kiro/endpoint/cli.rs
+++ b/src/kiro/endpoint/cli.rs
@@ -1,0 +1,169 @@
+//! Kiro CLI 端点（Amazon Q for CLI）
+//!
+//! 对应 Kiro CLI / Amazon Q for CLI 使用的 AWS JSON 协议端点：
+//! - URL: `https://q.{api_region}.amazonaws.com/`（根路径 + x-amz-target 头）
+//! - Content-Type: `application/x-amz-json-1.0`
+//! - User-Agent: aws-sdk-rust 格式
+//! - 请求体 origin: `KIRO_CLI`
+//!
+//! 适用于使用 `ksk_` 前缀 API Key 的凭据。
+
+use reqwest::RequestBuilder;
+use uuid::Uuid;
+
+use super::{KiroEndpoint, RequestContext};
+
+pub const CLI_ENDPOINT_NAME: &str = "cli";
+
+pub struct CliEndpoint;
+
+impl CliEndpoint {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn api_region<'a>(&self, ctx: &'a RequestContext<'_>) -> &'a str {
+        ctx.credentials.effective_api_region(ctx.config)
+    }
+
+    fn host(&self, ctx: &RequestContext<'_>) -> String {
+        format!("q.{}.amazonaws.com", self.api_region(ctx))
+    }
+
+    fn user_agent(&self, ctx: &RequestContext<'_>) -> String {
+        format!(
+            "aws-sdk-rust/1.3.15 ua/2.1 api/codewhispererstreaming/0.1.14474 os/{} lang/rust/1.92.0 md/appVersion-{} app/AmazonQ-For-CLI",
+            ctx.config.system_version,
+            ctx.config.kiro_version,
+        )
+    }
+
+    fn x_amz_user_agent(&self, ctx: &RequestContext<'_>) -> String {
+        format!(
+            "aws-sdk-rust/1.3.15 ua/2.1 api/codewhispererstreaming/0.1.14474 os/{} lang/rust/1.92.0 m/F app/AmazonQ-For-CLI",
+            ctx.config.system_version,
+        )
+    }
+}
+
+impl Default for CliEndpoint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KiroEndpoint for CliEndpoint {
+    fn name(&self) -> &'static str {
+        CLI_ENDPOINT_NAME
+    }
+
+    fn content_type(&self) -> &'static str {
+        "application/x-amz-json-1.0"
+    }
+
+    fn api_url(&self, ctx: &RequestContext<'_>) -> String {
+        format!("https://q.{}.amazonaws.com/", self.api_region(ctx))
+    }
+
+    fn mcp_url(&self, ctx: &RequestContext<'_>) -> String {
+        format!("https://q.{}.amazonaws.com/mcp", self.api_region(ctx))
+    }
+
+    fn decorate_api(&self, req: RequestBuilder, ctx: &RequestContext<'_>) -> RequestBuilder {
+        let mut req = req
+            .header(
+                "x-amz-target",
+                "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
+            )
+            .header("x-amzn-codewhisperer-optout", "false")
+            .header("x-amz-user-agent", self.x_amz_user_agent(ctx))
+            .header("user-agent", self.user_agent(ctx))
+            .header("host", self.host(ctx))
+            .header("amz-sdk-invocation-id", Uuid::new_v4().to_string())
+            .header("amz-sdk-request", "attempt=1; max=3")
+            .header("Authorization", format!("Bearer {}", ctx.token));
+
+        if ctx.credentials.is_api_key_credential() {
+            req = req.header("tokentype", "API_KEY");
+        }
+        req
+    }
+
+    fn decorate_mcp(&self, req: RequestBuilder, ctx: &RequestContext<'_>) -> RequestBuilder {
+        let mut req = req
+            .header("x-amz-user-agent", self.x_amz_user_agent(ctx))
+            .header("user-agent", self.user_agent(ctx))
+            .header("host", self.host(ctx))
+            .header("amz-sdk-invocation-id", Uuid::new_v4().to_string())
+            .header("amz-sdk-request", "attempt=1; max=3")
+            .header("Authorization", format!("Bearer {}", ctx.token));
+
+        if let Some(ref arn) = ctx.credentials.profile_arn {
+            req = req.header("x-amzn-kiro-profile-arn", arn);
+        }
+        if ctx.credentials.is_api_key_credential() {
+            req = req.header("tokentype", "API_KEY");
+        }
+        req
+    }
+
+    fn transform_api_body(&self, body: &str, _ctx: &RequestContext<'_>) -> String {
+        set_origin_kiro_cli(body)
+    }
+}
+
+/// 将请求体转换为 KIRO_CLI 格式：
+/// 1. 所有 "AI_EDITOR" origin 替换为 "KIRO_CLI"
+/// 2. 移除 conversationState.agentContinuationId（Kiro CLI 不发送此字段）
+/// 3. 移除 history 中用户消息的 modelId（Kiro CLI 不在历史消息里发送此字段）
+fn set_origin_kiro_cli(body: &str) -> String {
+    let body = body.replace("\"origin\":\"AI_EDITOR\"", "\"origin\":\"KIRO_CLI\"");
+
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&body) else {
+        return body;
+    };
+
+    if let Some(state) = json.get_mut("conversationState").and_then(|v| v.as_object_mut()) {
+        state.remove("agentContinuationId");
+
+        if let Some(history) = state.get_mut("history").and_then(|v| v.as_array_mut()) {
+            for msg in history.iter_mut() {
+                if let Some(user_input) = msg
+                    .get_mut("userInputMessage")
+                    .and_then(|v| v.as_object_mut())
+                {
+                    user_input.remove("modelId");
+                }
+            }
+        }
+    }
+
+    serde_json::to_string(&json).unwrap_or(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_origin_kiro_cli_current_message() {
+        let body = r#"{"conversationState":{"currentMessage":{"userInputMessage":{"content":"hi","origin":"AI_EDITOR"}}}}"#;
+        let result = set_origin_kiro_cli(body);
+        assert!(result.contains("\"origin\":\"KIRO_CLI\""));
+        assert!(!result.contains("\"origin\":\"AI_EDITOR\""));
+    }
+
+    #[test]
+    fn test_set_origin_kiro_cli_history() {
+        let body = r#"{"conversationState":{"history":[{"userInputMessage":{"content":"hi","origin":"AI_EDITOR"}},{"userInputMessage":{"content":"hello","origin":"AI_EDITOR"}}],"currentMessage":{"userInputMessage":{"origin":"AI_EDITOR"}}}}"#;
+        let result = set_origin_kiro_cli(body);
+        assert!(!result.contains("\"origin\":\"AI_EDITOR\""));
+        assert_eq!(result.matches("\"origin\":\"KIRO_CLI\"").count(), 3);
+    }
+
+    #[test]
+    fn test_set_origin_kiro_cli_no_origin() {
+        let body = r#"{"conversationState":{}}"#;
+        assert_eq!(set_origin_kiro_cli(body), r#"{"conversationState":{}}"#);
+    }
+}

--- a/src/kiro/endpoint/mod.rs
+++ b/src/kiro/endpoint/mod.rs
@@ -11,8 +11,10 @@ use reqwest::RequestBuilder;
 use crate::kiro::model::credentials::KiroCredentials;
 use crate::model::config::Config;
 
+pub mod cli;
 pub mod ide;
 
+pub use cli::CliEndpoint;
 pub use ide::IdeEndpoint;
 
 /// Kiro 端点
@@ -21,6 +23,11 @@ pub use ide::IdeEndpoint;
 pub trait KiroEndpoint: Send + Sync {
     /// 端点名称（对应 credentials.endpoint / config.defaultEndpoint 的取值）
     fn name(&self) -> &'static str;
+
+    /// API 请求的 Content-Type（默认 application/json）
+    fn content_type(&self) -> &'static str {
+        "application/json"
+    }
 
     /// API endpoint URL
     fn api_url(&self, ctx: &RequestContext<'_>) -> String;

--- a/src/kiro/model/requests/conversation.rs
+++ b/src/kiro/model/requests/conversation.rs
@@ -93,7 +93,7 @@ impl CurrentMessage {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInputMessage {
-    /// 用户输入消息上下文
+    /// 用户输入消息上下文（始终序列化，envState 是 CLI endpoint 必填字段）
     pub user_input_message_context: UserInputMessageContext,
     /// 消息内容
     pub content: String,
@@ -138,18 +138,54 @@ impl UserInputMessage {
     }
 }
 
+/// 环境状态（kiro-cli 始终发送此字段，CLI endpoint 要求）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvState {
+    pub operating_system: String,
+    pub current_working_directory: String,
+}
+
+impl Default for EnvState {
+    fn default() -> Self {
+        let cwd = std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "/".to_string());
+        Self {
+            operating_system: "macos".to_string(),
+            current_working_directory: cwd,
+        }
+    }
+}
+
 /// 用户输入消息上下文
 ///
 /// 包含工具定义和工具执行结果
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInputMessageContext {
+    /// 环境状态（kiro-cli 始终携带）
+    pub env_state: EnvState,
     /// 工具执行结果列表
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_results: Vec<ToolResult>,
     /// 可用工具列表
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<Tool>,
+}
+
+impl Default for UserInputMessageContext {
+    fn default() -> Self {
+        Self {
+            env_state: EnvState::default(),
+            tool_results: Vec::new(),
+            tools: Vec::new(),
+        }
+    }
+}
+
+fn is_empty_context(ctx: &UserInputMessageContext) -> bool {
+    ctx.tools.is_empty() && ctx.tool_results.is_empty()
 }
 
 impl UserInputMessageContext {
@@ -243,13 +279,9 @@ pub struct UserMessage {
     /// 图片列表
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<KiroImage>,
-    /// 用户输入消息上下文
-    #[serde(default, skip_serializing_if = "is_default_context")]
+    /// 用户输入消息上下文（历史消息无工具时跳过）
+    #[serde(default, skip_serializing_if = "is_empty_context")]
     pub user_input_message_context: UserInputMessageContext,
-}
-
-fn is_default_context(ctx: &UserInputMessageContext) -> bool {
-    ctx.tools.is_empty() && ctx.tool_results.is_empty()
 }
 
 impl UserMessage {

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -333,7 +333,14 @@ impl KiroProvider {
                 .header("Connection", "close");
             let request = endpoint.decorate_api(base, &rctx);
 
-            let response = match request.send().await {
+            // 打印实际发送的请求头（RUST_LOG=debug 时输出，便于排查问题）
+            let request = request.build().map_err(|e| anyhow::anyhow!("构建请求失败: {}", e))?;
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                for (k, v) in request.headers() {
+                    tracing::debug!("  header {}: {}", k, v.to_str().unwrap_or("<binary>"));
+                }
+            }
+            let response = match self.client_for(&ctx.credentials)?.execute(request).await {
                 Ok(resp) => resp,
                 Err(e) => {
                     tracing::warn!(

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -169,7 +169,7 @@ impl KiroProvider {
                 .client_for(&ctx.credentials)?
                 .post(&url)
                 .body(body)
-                .header("content-type", "application/json")
+                .header("content-type", endpoint.content_type())
                 .header("Connection", "close");
             let request = endpoint.decorate_mcp(base, &rctx);
 
@@ -322,11 +322,14 @@ impl KiroProvider {
             let url = endpoint.api_url(&rctx);
             let body = endpoint.transform_api_body(request_body, &rctx);
 
+            tracing::debug!("使用端点 [{}] POST {}", endpoint.name(), url);
+            tracing::debug!("实际发送请求体: {}", body);
+
             let base = self
                 .client_for(&ctx.credentials)?
                 .post(&url)
                 .body(body)
-                .header("content-type", "application/json")
+                .header("content-type", endpoint.content_type())
                 .header("Connection", "close");
             let request = endpoint.decorate_api(base, &rctx);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use clap::Parser;
-use kiro::endpoint::{IdeEndpoint, KiroEndpoint};
+use kiro::endpoint::{CliEndpoint, IdeEndpoint, KiroEndpoint};
 use kiro::model::credentials::{CredentialsConfig, KiroCredentials};
 use kiro::provider::KiroProvider;
 use kiro::token_manager::MultiTokenManager;
@@ -101,6 +101,8 @@ async fn main() {
     {
         let ide = IdeEndpoint::new();
         endpoints.insert(ide.name().to_string(), Arc::new(ide));
+        let cli = CliEndpoint::new();
+        endpoints.insert(cli.name().to_string(), Arc::new(cli));
     }
 
     // 校验默认端点存在

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -127,12 +127,11 @@ fn default_region() -> String {
 }
 
 fn default_kiro_version() -> String {
-    "0.11.107".to_string()
+    "2.3.0".to_string()
 }
 
 fn default_system_version() -> String {
-    const SYSTEM_VERSIONS: &[&str] = &["darwin#24.6.0", "win32#10.0.22631"];
-    SYSTEM_VERSIONS[fastrand::usize(..SYSTEM_VERSIONS.len())].to_string()
+    "macos".to_string()
 }
 
 fn default_node_version() -> String {


### PR DESCRIPTION
## 背景

将凭据 `endpoint` 字段设为 `cli` 后，kiro API 返回 `ValidationException: "Improperly formed request."`，经过 debug 日志 + 逐步二分测试定位了三类根本原因。

## 根本原因

### 1. MCP 工具空描述触发 Smithy 校验失败（最主要）

CLI endpoint 使用 AWS JSON 1.0 协议，服务端对 `ToolSpecification.description` 有 `@length(min: 1)` 约束。来自 gitea MCP 等服务的 26 个工具 description 为空字符串，导致每次请求都报错。

**修复**：`convert_tools` 中对空描述自动填充工具名作为占位符。

### 2. 工具 schema 包含 Draft 2020-12 特有字段

Claude Code / MCP 工具定义使用 JSON Schema Draft 2020-12 语法（`$schema` 声明、数字形式的 `exclusiveMinimum`/`exclusiveMaximum`、超出 i32 范围的 `maximum`/`minimum`），与 kiro API 期望的 Draft 07 格式冲突。

**修复**：`normalize_json_schema` 增强，增加递归处理 properties 子 schema，清理不兼容字段。

### 3. CLI endpoint 结构差异

CLI endpoint 的 Smithy schema 要求 `userInputMessageContext.envState` 非空，且对请求头格式有特定要求。

**修复**：新增 `EnvState` 结构体（OS + CWD），统一 user-agent 格式与版本号。

## 变更列表

- `src/kiro/endpoint/cli.rs` ✨ 新文件：CLI endpoint 实现（AWS JSON 1.0 协议）
- `src/kiro/endpoint/mod.rs`：注册 CLI endpoint，导出相关类型
- `src/main.rs`：构建端点注册表，支持按凭据 `endpoint` 字段选择
- `src/kiro/provider.rs`：端点路由 + 保留请求头 debug 日志（`RUST_LOG=debug`）
- `src/anthropic/converter.rs`：空描述填充 + schema 规范化增强
- `src/kiro/model/requests/conversation.rs`：新增 `EnvState`，`UserInputMessageContext` 加入 env_state
- `src/model/config.rs`：kiro_version 更新为 `2.3.0`，system_version 固定为 `macos`

## 排查过程

1. `RUST_LOG=debug` 抓取实际发送的请求体
2. 与 kiro-cli 抓包对比，逐项排除 headers / body 字段差异
3. 用 curl 直接测试不同数量工具的 body，定位到第 7 个工具时失败
4. 单工具测试 → 全部通过 → 问题在组合
5. 对比有无空描述的同一工具 → 空描述必现失败 → 确认根本原因

## 测试

在本地环境使用 opencode 连接代理，验证有空描述工具（64 个工具，含 26 个空描述）的请求正常响应，无 `ValidationException`。