### PR TITLE
fix(kiro): IdC/Builder ID 凭据请求不再携带 profileArn

### DIFF
--- a/src/kiro/endpoint/ide.rs
+++ b/src/kiro/endpoint/ide.rs
@@ -4,12 +4,15 @@
 //! - API: `https://q.{api_region}.amazonaws.com/generateAssistantResponse`
 //! - MCP: `https://q.{api_region}.amazonaws.com/mcp`
 //!
-//! 请求头使用 aws-sdk-js User-Agent 标识。请求体会在根对象上注入 `profileArn`。
+//! 请求头使用 aws-sdk-js User-Agent 标识。
+//! 对 Social 凭据，请求体会在根对象上注入 `profileArn`；
+//! 对 Builder/IdC 凭据，不携带任何 `profileArn` 相关字段。
 
 use reqwest::RequestBuilder;
 use uuid::Uuid;
 
 use super::{KiroEndpoint, RequestContext};
+use crate::kiro::model::credentials::KiroCredentials;
 
 /// Kiro IDE 端点名称
 pub const IDE_ENDPOINT_NAME: &str = "ide";
@@ -45,6 +48,10 @@ impl IdeEndpoint {
             ctx.config.kiro_version,
             ctx.machine_id
         )
+    }
+
+    fn profile_arn_for_request<'a>(&self, credentials: &'a KiroCredentials) -> Option<&'a str> {
+        credentials.profile_arn_for_request()
     }
 }
 
@@ -96,7 +103,7 @@ impl KiroEndpoint for IdeEndpoint {
             .header("amz-sdk-request", "attempt=1; max=3")
             .header("Authorization", format!("Bearer {}", ctx.token));
 
-        if let Some(ref arn) = ctx.credentials.profile_arn {
+        if let Some(arn) = self.profile_arn_for_request(ctx.credentials) {
             req = req.header("x-amzn-kiro-profile-arn", arn);
         }
         if ctx.credentials.is_api_key_credential() {
@@ -106,33 +113,47 @@ impl KiroEndpoint for IdeEndpoint {
     }
 
     fn transform_api_body(&self, body: &str, ctx: &RequestContext<'_>) -> String {
-        inject_profile_arn(body, &ctx.credentials.profile_arn)
+        inject_profile_arn(body, ctx.credentials)
     }
 }
 
 /// 将 profile_arn 注入到请求体 JSON 根对象
-fn inject_profile_arn(request_body: &str, profile_arn: &Option<String>) -> String {
-    if let Some(arn) = profile_arn {
-        if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(request_body) {
-            json["profileArn"] = serde_json::Value::String(arn.clone());
-            if let Ok(body) = serde_json::to_string(&json) {
-                return body;
-            }
+fn inject_profile_arn(request_body: &str, credentials: &KiroCredentials) -> String {
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(request_body) else {
+        return request_body.to_string();
+    };
+
+    if credentials.is_aws_sso_oidc_credential() {
+        if let Some(obj) = json.as_object_mut() {
+            obj.remove("profileArn");
+        }
+        return serde_json::to_string(&json).unwrap_or_else(|_| request_body.to_string());
+    }
+
+    if let Some(arn) = credentials.profile_arn_for_request() {
+        json["profileArn"] = serde_json::Value::String(arn.to_string());
+        if let Ok(body) = serde_json::to_string(&json) {
+            return body;
         }
     }
+
     request_body.to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::inject_profile_arn;
+    use crate::kiro::model::credentials::KiroCredentials;
     use serde_json::Value;
 
     #[test]
     fn test_inject_profile_arn_with_some() {
         let body = r#"{"conversationState":{"conversationId":"c1"}}"#;
-        let arn = Some("arn:aws:codewhisperer:us-east-1:123:profile/ABC".to_string());
-        let result = inject_profile_arn(body, &arn);
+        let credentials = KiroCredentials {
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123:profile/ABC".to_string()),
+            ..Default::default()
+        };
+        let result = inject_profile_arn(body, &credentials);
         let json: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(
             json["profileArn"],
@@ -144,7 +165,7 @@ mod tests {
     #[test]
     fn test_inject_profile_arn_with_none() {
         let body = r#"{"conversationState":{"conversationId":"c1"}}"#;
-        let result = inject_profile_arn(body, &None);
+        let result = inject_profile_arn(body, &KiroCredentials::default());
         let json: Value = serde_json::from_str(&result).unwrap();
         assert!(json.get("profileArn").is_none());
         assert_eq!(json["conversationState"]["conversationId"], "c1");
@@ -153,17 +174,38 @@ mod tests {
     #[test]
     fn test_inject_profile_arn_overwrites_existing() {
         let body = r#"{"conversationState":{},"profileArn":"old-arn"}"#;
-        let arn = Some("new-arn".to_string());
-        let result = inject_profile_arn(body, &arn);
+        let credentials = KiroCredentials {
+            profile_arn: Some("new-arn".to_string()),
+            ..Default::default()
+        };
+        let result = inject_profile_arn(body, &credentials);
         let json: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(json["profileArn"], "new-arn");
     }
 
     #[test]
+    fn test_inject_profile_arn_removes_existing_for_idc() {
+        let body = r#"{"conversationState":{},"profileArn":"old-arn"}"#;
+        let credentials = KiroCredentials {
+            auth_method: Some("idc".to_string()),
+            profile_arn: Some("should-not-be-used".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            ..Default::default()
+        };
+        let result = inject_profile_arn(body, &credentials);
+        let json: Value = serde_json::from_str(&result).unwrap();
+        assert!(json.get("profileArn").is_none());
+    }
+
+    #[test]
     fn test_inject_profile_arn_invalid_json() {
         let body = "not-valid-json";
-        let arn = Some("arn:test".to_string());
-        let result = inject_profile_arn(body, &arn);
+        let credentials = KiroCredentials {
+            profile_arn: Some("arn:test".to_string()),
+            ..Default::default()
+        };
+        let result = inject_profile_arn(body, &credentials);
         assert_eq!(result, "not-valid-json");
     }
 }

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -272,6 +272,29 @@ impl KiroCredentials {
                 .map(|m| m.eq_ignore_ascii_case("api_key") || m.eq_ignore_ascii_case("apikey"))
                 .unwrap_or(false)
     }
+
+    /// 检查是否为 AWS SSO OIDC / Builder 凭据。
+    ///
+    /// 这类凭据在实际请求阶段不应携带 `profileArn` 相关 header/body/query 参数，
+    /// 否则可能被上游判定为无效 bearer token。
+    pub fn is_aws_sso_oidc_credential(&self) -> bool {
+        self.auth_method
+            .as_deref()
+            .map(|m| m.eq_ignore_ascii_case("builder-id") || m.eq_ignore_ascii_case("idc"))
+            .unwrap_or(false)
+            || (self.client_id.is_some() && self.client_secret.is_some())
+    }
+
+    /// 返回请求阶段允许携带的 profileArn。
+    ///
+    /// Social 凭据可以携带；Builder/IdC 凭据必须省略。
+    pub fn profile_arn_for_request(&self) -> Option<&str> {
+        if self.is_aws_sso_oidc_credential() {
+            None
+        } else {
+            self.profile_arn.as_deref()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -320,6 +320,23 @@ async fn refresh_idc_token(
 }
 
 /// 获取使用额度信息
+fn build_usage_limits_url(credentials: &KiroCredentials, config: &Config) -> String {
+    let host = format!(
+        "q.{}.amazonaws.com",
+        credentials.effective_api_region(config)
+    );
+    let mut url = format!(
+        "https://{}/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST",
+        host
+    );
+
+    if let Some(profile_arn) = credentials.profile_arn_for_request() {
+        url.push_str(&format!("&profileArn={}", urlencoding::encode(profile_arn)));
+    }
+
+    url
+}
+
 pub(crate) async fn get_usage_limits(
     credentials: &KiroCredentials,
     config: &Config,
@@ -337,15 +354,7 @@ pub(crate) async fn get_usage_limits(
     let node_version = &config.node_version;
 
     // 构建 URL
-    let mut url = format!(
-        "https://{}/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST",
-        host
-    );
-
-    // profileArn 是可选的
-    if let Some(profile_arn) = &credentials.profile_arn {
-        url.push_str(&format!("&profileArn={}", urlencoding::encode(profile_arn)));
-    }
+    let url = build_usage_limits_url(credentials, config);
 
     // 构建 User-Agent headers
     let user_agent = format!(
@@ -2567,6 +2576,41 @@ mod tests {
         let api_host = format!("q.{}.amazonaws.com", api_region);
 
         assert_eq!(api_host, "q.eu-central-1.amazonaws.com");
+    }
+
+    #[test]
+    fn test_usage_limits_url_includes_profile_arn_for_social() {
+        let mut config = Config::default();
+        config.region = "us-east-1".to_string();
+
+        let credentials = KiroCredentials {
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123:profile/ABC".to_string()),
+            ..Default::default()
+        };
+
+        let url = build_usage_limits_url(&credentials, &config);
+        assert!(url.contains("q.us-east-1.amazonaws.com/getUsageLimits"));
+        assert!(
+            url.contains("profileArn=arn%3Aaws%3Acodewhisperer%3Aus-east-1%3A123%3Aprofile%2FABC")
+        );
+    }
+
+    #[test]
+    fn test_usage_limits_url_omits_profile_arn_for_idc() {
+        let mut config = Config::default();
+        config.region = "us-east-1".to_string();
+
+        let credentials = KiroCredentials {
+            auth_method: Some("idc".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123:profile/ABC".to_string()),
+            ..Default::default()
+        };
+
+        let url = build_usage_limits_url(&credentials, &config);
+        assert!(url.contains("q.us-east-1.amazonaws.com/getUsageLimits"));
+        assert!(!url.contains("profileArn="));
     }
 
     #[test]


### PR DESCRIPTION
AWS SSO OIDC 凭据(Builder ID / IdC)在调用 generateAssistantResponse、MCP 和 getUsageLimits 时若携带 profileArn,会被上游判定为无效 bearer token。 Social 凭据保持原行为。见issue https://github.com/hank9999/kiro.rs/issues/161

- 新增 KiroCredentials::is_aws_sso_oidc_credential 与 profile_arn_for_request,统一判断与取值入口
- IDE 端点 MCP header、API body、getUsageLimits URL 三处统一走 profile_arn_for_request,IdC 凭据自动剥离 profileArn
- API body 中若已存在 profileArn,IdC 凭据下会主动移除
- 抽出 build_usage_limits_url helper,补充 Social/IdC 单测

## 影响范围

  - Social 凭据:行为不变,继续在 header/body/query 中携带 `profileArn`
  - IdC / Builder ID 凭据:三处出站请求都不再携带 `profileArn`
  - API Key 凭据:不受影响