### PR TITLE
feat(anthropic): 增加对 Claude Opus 4.8 的支持

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -95,6 +95,8 @@ pub fn map_model(model: &str) -> Option<String> {
             Some("claude-opus-4.6".to_string())
         } else if model_lower.contains("4-7") || model_lower.contains("4.7") {
             Some("claude-opus-4.7".to_string())
+        } else if model_lower.contains("4-8") || model_lower.contains("4.8") {
+            Some("claude-opus-4.8".to_string())
         } else {
             None
         }
@@ -109,10 +111,10 @@ pub fn map_model(model: &str) -> Option<String> {
 ///
 /// 复用 `map_model` 的映射逻辑，确保窗口大小判断与模型映射一致。
 /// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
-/// 4.7 同 1M
+/// 4.7 / 4.8 同 1M
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
-        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" => 1_000_000,
+        Some(mapped) if mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" || mapped == "claude-opus-4.8" => 1_000_000,
         _ => 200_000,
     }
 }
@@ -952,6 +954,19 @@ mod tests {
         // thinking 后缀不应影响 opus 4.6 模型映射
         let result = map_model("claude-opus-4-6-thinking");
         assert_eq!(result, Some("claude-opus-4.6".to_string()));
+    }
+
+    #[test]
+    fn test_map_model_opus_4_8() {
+        assert_eq!(
+            map_model("claude-opus-4-8"),
+            Some("claude-opus-4.8".to_string())
+        );
+        assert_eq!(
+            map_model("claude-opus-4-8-thinking"),
+            Some("claude-opus-4.8".to_string())
+        );
+        assert_eq!(get_context_window_size("claude-opus-4-8"), 1_000_000);
     }
 
     #[test]

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -75,6 +75,24 @@ pub async fn get_models() -> impl IntoResponse {
 
     let models = vec![
         Model {
+            id: "claude-opus-4-8".to_string(),
+            object: "model".to_string(),
+            created: 1779897600, // May 28, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 4.8".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
+            id: "claude-opus-4-8-thinking".to_string(),
+            object: "model".to_string(),
+            created: 1779897600, // May 28, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 4.8 (Thinking)".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
             id: "claude-opus-4-7".to_string(),
             object: "model".to_string(),
             created: 1776276000, // Apr 16, 2026


### PR DESCRIPTION
## Summary

- 将 `claude-opus-4-8` / `claude-opus-4-8-thinking` 映射至 Kiro 模型 ID `claude-opus-4.8`
- 上下文窗口 1M tokens（与 Opus 4.6/4.7 一致）
- `GET /v1/models` 中 Opus 4.8 的 `max_tokens` 为 128K（对齐官方规格）
- 新增单元测试 `test_map_model_opus_4_8`

## Test plan

- [x] `cargo test test_map_model_opus_4_8`