### PR TITLE
feat(admin): 支持凭据自定义名称

### DIFF
--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -6,6 +6,7 @@ import type {
   SuccessResponse,
   SetDisabledRequest,
   SetPriorityRequest,
+  SetNameRequest,
   AddCredentialRequest,
   AddCredentialResponse,
 } from '@/types/api'
@@ -53,6 +54,18 @@ export async function setCredentialPriority(
   const { data } = await api.post<SuccessResponse>(
     `/credentials/${id}/priority`,
     { priority } as SetPriorityRequest
+  )
+  return data
+}
+
+// 设置凭据名称
+export async function setCredentialName(
+  id: number,
+  name: string | null
+): Promise<SuccessResponse> {
+  const { data } = await api.post<SuccessResponse>(
+    `/credentials/${id}/name`,
+    { name } as SetNameRequest
   )
   return data
 }

--- a/admin-ui/src/components/add-credential-dialog.tsx
+++ b/admin-ui/src/components/add-credential-dialog.tsx
@@ -21,6 +21,7 @@ type AuthMethod = 'social' | 'idc' | 'api_key'
 
 export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogProps) {
   const [refreshToken, setRefreshToken] = useState('')
+  const [name, setName] = useState('')
   const [kiroApiKey, setKiroApiKey] = useState('')
   const [authMethod, setAuthMethod] = useState<AuthMethod>('social')
   const [authRegion, setAuthRegion] = useState('')
@@ -38,6 +39,7 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
 
   const resetForm = () => {
     setRefreshToken('')
+    setName('')
     setKiroApiKey('')
     setAuthMethod('social')
     setAuthRegion('')
@@ -77,6 +79,7 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
 
     mutate(
       {
+        name: name.trim() || undefined,
         authMethod,
         refreshToken: isApiKey ? undefined : refreshToken.trim(),
         kiroApiKey: isApiKey ? kiroApiKey.trim() : undefined,
@@ -113,6 +116,20 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
 
         <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
           <div className="space-y-4 py-4 overflow-y-auto flex-1 pr-1">
+            {/* 凭据名称 */}
+            <div className="space-y-2">
+              <label htmlFor="name" className="text-sm font-medium">
+                凭据名称
+              </label>
+              <Input
+                id="name"
+                placeholder="可选，用于标识凭据"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={isPending}
+              />
+            </div>
+
             {/* 认证方式 */}
             <div className="space-y-2">
               <label htmlFor="authMethod" className="text-sm font-medium">

--- a/admin-ui/src/components/batch-import-dialog.tsx
+++ b/admin-ui/src/components/batch-import-dialog.tsx
@@ -20,6 +20,7 @@ interface BatchImportDialogProps {
 
 interface CredentialInput {
   refreshToken?: string
+  name?: string
   clientId?: string
   clientSecret?: string
   region?: string
@@ -275,6 +276,7 @@ export function BatchImportDialog({ open, onOpenChange }: BatchImportDialogProps
 
           const addedCred = await addCredential({
             refreshToken: token,
+            name: cred.name?.trim() || undefined,
             authMethod,
             authRegion: cred.authRegion?.trim() || cred.region?.trim() || undefined,
             apiRegion: cred.apiRegion?.trim() || undefined,

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { RefreshCw, ChevronUp, ChevronDown, Wallet, Trash2, Loader2 } from 'lucide-react'
+import { RefreshCw, ChevronUp, ChevronDown, Wallet, Trash2, Loader2, Pencil } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -19,6 +19,7 @@ import type { CredentialStatusItem, BalanceResponse } from '@/types/api'
 import {
   useSetDisabled,
   useSetPriority,
+  useSetName,
   useResetFailure,
   useDeleteCredential,
   useForceRefreshToken,
@@ -59,10 +60,13 @@ export function CredentialCard({
 }: CredentialCardProps) {
   const [editingPriority, setEditingPriority] = useState(false)
   const [priorityValue, setPriorityValue] = useState(String(credential.priority))
+  const [editingName, setEditingName] = useState(false)
+  const [nameValue, setNameValue] = useState(credential.name || '')
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   const setDisabled = useSetDisabled()
   const setPriority = useSetPriority()
+  const setName = useSetName()
   const resetFailure = useResetFailure()
   const deleteCredential = useDeleteCredential()
   const forceRefresh = useForceRefreshToken()
@@ -152,7 +156,78 @@ export function CredentialCard({
                 onCheckedChange={onToggleSelect}
               />
               <CardTitle className="text-lg flex items-center gap-2">
-                {credential.email || `凭据 #${credential.id}`}
+                {editingName ? (
+                  <div className="inline-flex items-center gap-1">
+                    <Input
+                      value={nameValue}
+                      onChange={(e) => setNameValue(e.target.value)}
+                      className="w-40 h-7 text-sm"
+                      placeholder="输入名称"
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          const trimmed = nameValue.trim()
+                          setName.mutate(
+                            { id: credential.id, name: trimmed || null },
+                            {
+                              onSuccess: (res) => {
+                                toast.success(res.message)
+                                setEditingName(false)
+                              },
+                              onError: (err) => toast.error('操作失败: ' + (err as Error).message),
+                            }
+                          )
+                        } else if (e.key === 'Escape') {
+                          setEditingName(false)
+                          setNameValue(credential.name || '')
+                        }
+                      }}
+                    />
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-7 p-0"
+                      onClick={() => {
+                        const trimmed = nameValue.trim()
+                        setName.mutate(
+                          { id: credential.id, name: trimmed || null },
+                          {
+                            onSuccess: (res) => {
+                              toast.success(res.message)
+                              setEditingName(false)
+                            },
+                            onError: (err) => toast.error('操作失败: ' + (err as Error).message),
+                          }
+                        )
+                      }}
+                      disabled={setName.isPending}
+                    >
+                      ✓
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-7 p-0"
+                      onClick={() => {
+                        setEditingName(false)
+                        setNameValue(credential.name || '')
+                      }}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                ) : (
+                  <span className="flex items-center gap-1">
+                    {credential.name || credential.email || `凭据 #${credential.id}`}
+                    <Pencil
+                      className="h-3.5 w-3.5 text-muted-foreground cursor-pointer hover:text-foreground"
+                      onClick={() => {
+                        setNameValue(credential.name || '')
+                        setEditingName(true)
+                      }}
+                    />
+                  </span>
+                )}
                 {credential.isCurrent && (
                   <Badge variant="success">当前</Badge>
                 )}

--- a/admin-ui/src/components/kam-import-dialog.tsx
+++ b/admin-ui/src/components/kam-import-dialog.tsx
@@ -276,6 +276,7 @@ export function KamImportDialog({ open, onOpenChange }: KamImportDialogProps) {
 
           const addedCred = await addCredential({
             refreshToken: token,
+            name: account.nickname?.trim() || account.email?.trim() || undefined,
             authMethod,
             authRegion: cred.region?.trim() || undefined,
             clientId,

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -3,6 +3,7 @@ import {
   getCredentials,
   setCredentialDisabled,
   setCredentialPriority,
+  setCredentialName,
   resetCredentialFailure,
   forceRefreshToken,
   getCredentialBalance,
@@ -50,6 +51,18 @@ export function useSetPriority() {
   return useMutation({
     mutationFn: ({ id, priority }: { id: number; priority: number }) =>
       setCredentialPriority(id, priority),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
+  })
+}
+
+// 设置名称
+export function useSetName() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, name }: { id: number; name: string | null }) =>
+      setCredentialName(id, name),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['credentials'] })
     },

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -9,6 +9,7 @@ export interface CredentialsStatusResponse {
 // 单个凭据状态
 export interface CredentialStatusItem {
   id: number
+  name?: string
   priority: number
   disabled: boolean
   failureCount: number
@@ -63,9 +64,14 @@ export interface SetPriorityRequest {
   priority: number
 }
 
+export interface SetNameRequest {
+  name: string | null
+}
+
 // 添加凭据请求
 export interface AddCredentialRequest {
   refreshToken?: string
+  name?: string
   authMethod?: 'social' | 'idc' | 'api_key'
   clientId?: string
   clientSecret?: string

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -9,8 +9,8 @@ use axum::{
 use super::{
     middleware::AdminState,
     types::{
-        AddCredentialRequest, SetDisabledRequest, SetLoadBalancingModeRequest, SetPriorityRequest,
-        SuccessResponse,
+        AddCredentialRequest, SetDisabledRequest, SetLoadBalancingModeRequest, SetNameRequest,
+        SetPriorityRequest, SuccessResponse,
     },
 };
 
@@ -50,6 +50,26 @@ pub async fn set_credential_priority(
             id, payload.priority
         )))
         .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// POST /api/admin/credentials/:id/name
+/// 设置凭据名称
+pub async fn set_credential_name(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+    Json(payload): Json<SetNameRequest>,
+) -> impl IntoResponse {
+    let name = payload.name.filter(|n| !n.trim().is_empty());
+    match state.service.set_name(id, name.clone()) {
+        Ok(_) => {
+            let msg = match &name {
+                Some(n) => format!("凭据 #{} 名称已设置为 {}", id, n),
+                None => format!("凭据 #{} 名称已清除", id),
+            };
+            Json(SuccessResponse::new(msg)).into_response()
+        }
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
 }

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -9,7 +9,8 @@ use super::{
     handlers::{
         add_credential, delete_credential, force_refresh_token, get_all_credentials,
         get_credential_balance, get_load_balancing_mode, reset_failure_count,
-        set_credential_disabled, set_credential_priority, set_load_balancing_mode,
+        set_credential_disabled, set_credential_name, set_credential_priority,
+        set_load_balancing_mode,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -41,6 +42,7 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/credentials/{id}", delete(delete_credential))
         .route("/credentials/{id}/disabled", post(set_credential_disabled))
         .route("/credentials/{id}/priority", post(set_credential_priority))
+        .route("/credentials/{id}/name", post(set_credential_name))
         .route("/credentials/{id}/reset", post(reset_failure_count))
         .route("/credentials/{id}/refresh", post(force_refresh_token))
         .route("/credentials/{id}/balance", get(get_credential_balance))

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -69,6 +69,7 @@ impl AdminService {
             .into_iter()
             .map(|entry| CredentialStatusItem {
                 id: entry.id,
+                name: entry.name.clone(),
                 priority: entry.priority,
                 disabled: entry.disabled,
                 failure_count: entry.failure_count,
@@ -122,6 +123,13 @@ impl AdminService {
     pub fn set_priority(&self, id: u64, priority: u32) -> Result<(), AdminServiceError> {
         self.token_manager
             .set_priority(id, priority)
+            .map_err(|e| self.classify_error(e, id))
+    }
+
+    /// 设置凭据名称
+    pub fn set_name(&self, id: u64, name: Option<String>) -> Result<(), AdminServiceError> {
+        self.token_manager
+            .set_name(id, name)
             .map_err(|e| self.classify_error(e, id))
     }
 
@@ -215,6 +223,7 @@ impl AdminService {
         let email = req.email.clone();
         let new_cred = KiroCredentials {
             id: None,
+            name: req.name,
             access_token: None,
             refresh_token: req.refresh_token,
             profile_arn: None,

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -24,6 +24,9 @@ pub struct CredentialsStatusResponse {
 pub struct CredentialStatusItem {
     /// 凭据唯一 ID
     pub id: u64,
+    /// 凭据自定义名称
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     /// 优先级（数字越小优先级越高）
     pub priority: u32,
     /// 是否被禁用
@@ -82,12 +85,23 @@ pub struct SetPriorityRequest {
     pub priority: u32,
 }
 
+/// 修改凭据名称请求
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetNameRequest {
+    /// 新名称（空字符串表示清除名称）
+    pub name: Option<String>,
+}
+
 /// 添加凭据请求
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddCredentialRequest {
     /// 刷新令牌（OAuth 凭据必填，API Key 凭据不需要）
     pub refresh_token: Option<String>,
+
+    /// 凭据自定义名称（可选）
+    pub name: Option<String>,
 
     /// 认证方式（可选，默认 social）
     #[serde(default = "default_auth_method")]

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -18,6 +18,10 @@ pub struct KiroCredentials {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<u64>,
 
+    /// 凭据自定义名称（可选，用于 Admin UI 显示）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
     /// 访问令牌
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_token: Option<String>,
@@ -323,6 +327,7 @@ mod tests {
     fn test_to_json() {
         let creds = KiroCredentials {
             id: None,
+            name: None,
             access_token: Some("token".to_string()),
             refresh_token: None,
             profile_arn: None,
@@ -441,6 +446,7 @@ mod tests {
     fn test_region_field_serialization() {
         let creds = KiroCredentials {
             id: None,
+            name: None,
             access_token: None,
             refresh_token: Some("test".to_string()),
             profile_arn: None,
@@ -472,6 +478,7 @@ mod tests {
     fn test_region_field_none_not_serialized() {
         let creds = KiroCredentials {
             id: None,
+            name: None,
             access_token: None,
             refresh_token: Some("test".to_string()),
             profile_arn: None,
@@ -586,6 +593,7 @@ mod tests {
         // 测试序列化和反序列化的往返一致性
         let original = KiroCredentials {
             id: Some(42),
+            name: None,
             access_token: Some("token".to_string()),
             refresh_token: Some("refresh".to_string()),
             profile_arn: None,

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -450,6 +450,9 @@ struct StatsEntry {
 pub struct CredentialEntrySnapshot {
     /// 凭据唯一 ID
     pub id: u64,
+    /// 凭据自定义名称
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     /// 优先级
     pub priority: u32,
     /// 是否被禁用
@@ -1404,6 +1407,7 @@ impl MultiTokenManager {
                 .iter()
                 .map(|e| CredentialEntrySnapshot {
                     id: e.id,
+                    name: e.credentials.name.clone(),
                     priority: e.credentials.priority,
                     disabled: e.disabled,
                     failure_count: e.failure_count,
@@ -1501,6 +1505,20 @@ impl MultiTokenManager {
         // 立即按新优先级重新选择当前凭据（无论持久化是否成功）
         self.select_highest_priority();
         // 持久化更改
+        self.persist_credentials()?;
+        Ok(())
+    }
+
+    /// 设置凭据名称（Admin API）
+    pub fn set_name(&self, id: u64, name: Option<String>) -> anyhow::Result<()> {
+        {
+            let mut entries = self.entries.lock();
+            let entry = entries
+                .iter_mut()
+                .find(|e| e.id == id)
+                .ok_or_else(|| anyhow::anyhow!("凭据不存在: {}", id))?;
+            entry.credentials.name = name;
+        }
         self.persist_credentials()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

为凭据添加可选的自定义名称字段，方便用户在多凭据场景下区分和管理。

## 变更内容

### 后端
- `KiroCredentials` 模型新增 `name: Option<String>` 字段
- 新增 `POST /credentials/{id}/name` API 端点，支持设置/清除凭据名称
- `get_all_credentials` 响应中包含 name 字段
- 添加凭据时支持传入初始名称

### 前端
- 凭据卡片标题支持显示自定义名称，优先级：name > email > 凭据 #ID
- 凭据卡片支持点击编辑名称（内联编辑模式，Enter 保存，Escape 取消）
- 添加凭据对话框新增「凭据名称」输入字段（可选）
- 批量导入和 KAM 导入支持传入名称

### API

```
POST /credentials/{id}/name
Body: { "name": "my-credential" }  // 设置名称
Body: { "name": null }             // 清除名称
```

## Test Plan
- [x] 添加凭据时设置名称，验证凭据卡片正确显示
- [x] 点击编辑已有凭据名称，按 Enter 保存，验证持久化
- [x] 清空名称后保存，验证回退到 email 显示
- [x] 批量导入带名称的凭据，验证正确显示
- [x] 重启服务后验证名称仍然保留