### PR TITLE
fix(ui): 修复凭据管理界面的按钮换行与文本竖排/溢出

### DIFF
--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -145,25 +145,26 @@ export function CredentialCard({
     <>
       <Card className={credential.isCurrent ? 'ring-2 ring-primary' : ''}>
         <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-start gap-2 min-w-0 flex-wrap">
               <Checkbox
                 checked={selected}
                 onCheckedChange={onToggleSelect}
+                className="mt-1 shrink-0"
               />
-              <CardTitle className="text-lg flex items-center gap-2">
-                {credential.email || `凭据 #${credential.id}`}
+              <CardTitle className="text-lg flex items-center gap-2 flex-wrap min-w-0">
+                <span className="break-all">{credential.email || `凭据 #${credential.id}`}</span>
                 {credential.isCurrent && (
-                  <Badge variant="success">当前</Badge>
+                  <Badge variant="success" className="whitespace-nowrap shrink-0">当前</Badge>
                 )}
                 {credential.disabled && (
-                  <Badge variant="destructive">已禁用</Badge>
+                  <Badge variant="destructive" className="whitespace-nowrap shrink-0">已禁用</Badge>
                 )}
                 {credential.disabled && credential.disabledReason && (
-                  <Badge variant="outline">{credential.disabledReason}</Badge>
+                  <Badge variant="outline" className="whitespace-nowrap shrink-0">{credential.disabledReason}</Badge>
                 )}
                 {credential.authMethod && (
-                  <Badge variant="secondary">
+                  <Badge variant="secondary" className="whitespace-nowrap shrink-0">
                     {credential.authMethod === 'api_key' ? 'API Key' :
                      credential.authMethod === 'idc' ? 'IdC' :
                      credential.authMethod === 'social' ? 'Social' :
@@ -171,12 +172,12 @@ export function CredentialCard({
                   </Badge>
                 )}
                 {credential.endpoint && (
-                  <Badge variant="outline">{credential.endpoint}</Badge>
+                  <Badge variant="outline" className="whitespace-nowrap shrink-0">{credential.endpoint}</Badge>
                 )}
               </CardTitle>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">启用</span>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-sm text-muted-foreground whitespace-nowrap">启用</span>
               <Switch
                 checked={!credential.disabled}
                 onCheckedChange={handleToggleDisabled}
@@ -261,7 +262,7 @@ export function CredentialCard({
             {credential.maskedApiKey && (
               <div className="col-span-2">
                 <span className="text-muted-foreground">API Key：</span>
-                <span className="font-mono font-medium">{credential.maskedApiKey}</span>
+                <span className="font-mono font-medium break-all">{credential.maskedApiKey}</span>
               </div>
             )}
             <div className="col-span-2">

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -608,19 +608,19 @@ export function Dashboard({ onLogout }: DashboardProps) {
 
         {/* 凭据列表 */}
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <h2 className="text-xl font-semibold">凭据管理</h2>
+          <div className="flex items-center justify-between gap-4 flex-wrap">
+            <div className="flex items-center gap-4 shrink-0">
+              <h2 className="text-xl font-semibold whitespace-nowrap">凭据管理</h2>
               {selectedIds.size > 0 && (
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary">已选择 {selectedIds.size} 个</Badge>
-                  <Button onClick={deselectAll} size="sm" variant="ghost">
+                <div className="flex items-center gap-2 shrink-0">
+                  <Badge variant="secondary" className="whitespace-nowrap">已选择 {selectedIds.size} 个</Badge>
+                  <Button onClick={deselectAll} size="sm" variant="ghost" className="whitespace-nowrap">
                     取消选择
                   </Button>
                 </div>
               )}
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2 [&_button]:whitespace-nowrap [&_button]:shrink-0">
               {selectedIds.size > 0 && (
                 <>
                   <Button onClick={handleBatchVerify} size="sm" variant="outline">

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -620,7 +620,7 @@ export function Dashboard({ onLogout }: DashboardProps) {
                 </div>
               )}
             </div>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               {selectedIds.size > 0 && (
                 <>
                   <Button onClick={handleBatchVerify} size="sm" variant="outline">


### PR DESCRIPTION
## 问题

Admin UI 凭据管理界面在按钮较多、窗口较窄或邮箱/徽章文本较长时存在多处布局问题：

1. 选中凭据后，批量操作按钮容器使用 `flex gap-2` 未设置 `flex-wrap`，按钮会溢出容器。
2. 按钮换行后挤压左侧，"已选择 N 个"徽章被压成竖排。
3. 凭据卡片头部当邮箱过长或徽章较多时，徽章（API Key / Social / 当前 / 刷新失败原因等）被压成逐字竖排。
4. 较长的禁用原因徽章（如"Token 刷新失败次数过多"）和 API Key 值会溢出。

## 修改

- 操作栏容器添加 `flex-wrap`，按钮与徽章统一 `whitespace-nowrap shrink-0`，空间不足时整组按钮自然换行而非溢出或竖排。
- 凭据卡片头部改用 `items-start` + `flex-wrap`，徽章统一 `whitespace-nowrap shrink-0`，邮箱与 API Key 值使用 `break-all`。

## 测试

本地用 mock 数据预览，覆盖了禁用、刷新失败、带代理、长邮箱等各种状态，确认按钮在窄窗口下整齐换行、文本不再竖排或溢出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)