### PR TITLE
feat: 支持在管理面板修改客户端 apiKey 与管理员密码（即时生效）

### DIFF
--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -8,10 +8,11 @@ import type {
   SetPriorityRequest,
   AddCredentialRequest,
   AddCredentialResponse,
+  ApiKeyResponse,
 } from '@/types/api'
 
 // 创建 axios 实例
-const api = axios.create({
+export const api = axios.create({
   baseURL: '/api/admin',
   headers: {
     'Content-Type': 'application/json',
@@ -102,5 +103,23 @@ export async function getLoadBalancingMode(): Promise<{ mode: 'priority' | 'bala
 // 设置负载均衡模式
 export async function setLoadBalancingMode(mode: 'priority' | 'balanced'): Promise<{ mode: 'priority' | 'balanced' }> {
   const { data } = await api.put<{ mode: 'priority' | 'balanced' }>('/config/load-balancing', { mode })
+  return data
+}
+
+// 修改 Admin API Key（即时生效，旧 Key 立即失效）
+export async function updateAdminKey(key: string): Promise<SuccessResponse> {
+  const { data } = await api.put<SuccessResponse>('/config/admin-key', { key })
+  return data
+}
+
+// 修改客户端 API Key（即时生效）
+export async function updateClientKey(key: string): Promise<ApiKeyResponse> {
+  const { data } = await api.put<ApiKeyResponse>('/config/client-key', { key })
+  return data
+}
+
+// 随机生成并应用新的客户端 API Key
+export async function generateClientKey(): Promise<ApiKeyResponse> {
+  const { data } = await api.post<ApiKeyResponse>('/config/client-key/generate')
   return data
 }

--- a/admin-ui/src/components/admin-key-dialog.tsx
+++ b/admin-ui/src/components/admin-key-dialog.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { storage } from '@/lib/storage'
+import { updateAdminKey } from '@/api/credentials'
+import { extractErrorMessage } from '@/lib/utils'
+
+interface AdminKeyDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** 修改成功后回调（用于触发重新登录） */
+  onChanged: (newKey: string) => void
+}
+
+export function AdminKeyDialog({ open, onOpenChange, onChanged }: AdminKeyDialogProps) {
+  const [newKey, setNewKey] = useState('')
+  const [confirmKey, setConfirmKey] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const reset = () => {
+    setNewKey('')
+    setConfirmKey('')
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const key = newKey.trim()
+    if (!key) {
+      toast.error('请输入新的管理员密码')
+      return
+    }
+    if (key !== confirmKey.trim()) {
+      toast.error('两次输入的密码不一致')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await updateAdminKey(key)
+      // 当前会话用的还是旧 key，更新 storage 以便后续请求使用新 key
+      storage.setApiKey(key)
+      toast.success('管理员密码已更新')
+      reset()
+      onOpenChange(false)
+      onChanged(key)
+    } catch (err) {
+      toast.error(extractErrorMessage(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>修改管理员密码</DialogTitle>
+          <DialogDescription>
+            修改后立即生效，无需重启服务。当前登录会话会自动使用新密码。
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm text-muted-foreground">新密码</label>
+            <Input
+              type="password"
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value)}
+              placeholder="输入新的 Admin API Key"
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm text-muted-foreground">确认新密码</label>
+            <Input
+              type="password"
+              value={confirmKey}
+              onChange={(e) => setConfirmKey(e.target.value)}
+              placeholder="再次输入新密码"
+              autoComplete="new-password"
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              取消
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/admin-ui/src/components/client-key-dialog.tsx
+++ b/admin-ui/src/components/client-key-dialog.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { RefreshCw, Copy } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { updateClientKey, generateClientKey } from '@/api/credentials'
+import { extractErrorMessage } from '@/lib/utils'
+
+interface ClientKeyDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ClientKeyDialog({ open, onOpenChange }: ClientKeyDialogProps) {
+  const [keyValue, setKeyValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [generating, setGenerating] = useState(false)
+
+  const reset = () => {
+    setKeyValue('')
+  }
+
+  const handleGenerate = async () => {
+    setGenerating(true)
+    try {
+      // 直接调用后端生成并应用，返回明文 key
+      const res = await generateClientKey()
+      setKeyValue(res.apiKey)
+      toast.success('已生成并应用新的客户端 API Key')
+    } catch (err) {
+      toast.error(extractErrorMessage(err))
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!keyValue) return
+    try {
+      await navigator.clipboard.writeText(keyValue)
+      toast.success('已复制到剪贴板')
+    } catch {
+      toast.error('复制失败，请手动复制')
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const key = keyValue.trim()
+    if (!key) {
+      toast.error('请输入或生成一个 API Key')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await updateClientKey(key)
+      toast.success('客户端 API Key 已更新')
+      reset()
+      onOpenChange(false)
+    } catch (err) {
+      toast.error(extractErrorMessage(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>修改客户端 API Key</DialogTitle>
+          <DialogDescription>
+            用于客户端调用 /v1 接口的密钥。修改后立即生效，无需重启服务。
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm text-muted-foreground">API Key</label>
+            <div className="flex gap-2">
+              <Input
+                value={keyValue}
+                onChange={(e) => setKeyValue(e.target.value)}
+                placeholder="输入新的 API Key，或点击随机生成"
+                className="font-mono"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleCopy}
+                disabled={!keyValue}
+                title="复制"
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleGenerate}
+              disabled={generating}
+              className="w-full"
+            >
+              <RefreshCw className={`h-4 w-4 mr-2 ${generating ? 'animate-spin' : ''}`} />
+              {generating ? '生成中...' : '随机生成（sk-kiro-...）'}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              注意：点击「随机生成」会立即在服务端应用新 Key，旧 Key 随即失效。
+            </p>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              取消
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { RefreshCw, LogOut, Moon, Sun, Server, Plus, Upload, FileUp, Trash2, RotateCcw, CheckCircle2 } from 'lucide-react'
+import { RefreshCw, LogOut, Moon, Sun, Server, Plus, Upload, FileUp, Trash2, RotateCcw, CheckCircle2, Settings, KeyRound } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { storage } from '@/lib/storage'
@@ -12,6 +12,8 @@ import { AddCredentialDialog } from '@/components/add-credential-dialog'
 import { BatchImportDialog } from '@/components/batch-import-dialog'
 import { KamImportDialog } from '@/components/kam-import-dialog'
 import { BatchVerifyDialog, type VerifyResult } from '@/components/batch-verify-dialog'
+import { AdminKeyDialog } from '@/components/admin-key-dialog'
+import { ClientKeyDialog } from '@/components/client-key-dialog'
 import { useCredentials, useDeleteCredential, useResetFailure, useLoadBalancingMode, useSetLoadBalancingMode } from '@/hooks/use-credentials'
 import { getCredentialBalance, forceRefreshToken } from '@/api/credentials'
 import { extractErrorMessage } from '@/lib/utils'
@@ -27,6 +29,8 @@ export function Dashboard({ onLogout }: DashboardProps) {
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [batchImportDialogOpen, setBatchImportDialogOpen] = useState(false)
   const [kamImportDialogOpen, setKamImportDialogOpen] = useState(false)
+  const [adminKeyDialogOpen, setAdminKeyDialogOpen] = useState(false)
+  const [clientKeyDialogOpen, setClientKeyDialogOpen] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [verifyDialogOpen, setVerifyDialogOpen] = useState(false)
   const [verifying, setVerifying] = useState(false)
@@ -560,6 +564,14 @@ export function Dashboard({ onLogout }: DashboardProps) {
             <Button variant="ghost" size="icon" onClick={handleRefresh}>
               <RefreshCw className="h-5 w-5" />
             </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setAdminKeyDialogOpen(true)}
+              title="修改管理员密码"
+            >
+              <Settings className="h-5 w-5" />
+            </Button>
             <Button variant="ghost" size="icon" onClick={handleLogout}>
               <LogOut className="h-5 w-5" />
             </Button>
@@ -690,6 +702,10 @@ export function Dashboard({ onLogout }: DashboardProps) {
                 <Upload className="h-4 w-4 mr-2" />
                 批量导入
               </Button>
+              <Button onClick={() => setClientKeyDialogOpen(true)} size="sm" variant="outline">
+                <KeyRound className="h-4 w-4 mr-2" />
+                修改 API Key
+              </Button>
               <Button onClick={() => setAddDialogOpen(true)} size="sm">
                 <Plus className="h-4 w-4 mr-2" />
                 添加凭据
@@ -781,6 +797,20 @@ export function Dashboard({ onLogout }: DashboardProps) {
         results={verifyResults}
         onCancel={handleCancelVerify}
       />
+
+      {/* 修改管理员密码 */}
+      <AdminKeyDialog
+        open={adminKeyDialogOpen}
+        onOpenChange={setAdminKeyDialogOpen}
+        onChanged={() => {
+          // 管理员密码已变更，安全起见要求重新登录
+          toast.info('管理员密码已修改，请重新登录')
+          handleLogout()
+        }}
+      />
+
+      {/* 修改客户端 API Key */}
+      <ClientKeyDialog open={clientKeyDialogOpen} onOpenChange={setClientKeyDialogOpen} />
     </div>
   )
 }

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -46,6 +46,13 @@ export interface SuccessResponse {
   message: string
 }
 
+// 修改/生成 API Key 响应（含明文 key，仅返回一次）
+export interface ApiKeyResponse {
+  success: boolean
+  message: string
+  apiKey: string
+}
+
 // 错误响应
 export interface AdminErrorResponse {
   error: {

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -9,8 +9,8 @@ use axum::{
 use super::{
     middleware::AdminState,
     types::{
-        AddCredentialRequest, SetDisabledRequest, SetLoadBalancingModeRequest, SetPriorityRequest,
-        SuccessResponse,
+        AddCredentialRequest, ApiKeyResponse, SetDisabledRequest, SetLoadBalancingModeRequest,
+        SetPriorityRequest, SuccessResponse, UpdateApiKeyRequest,
     },
 };
 
@@ -137,6 +137,50 @@ pub async fn set_load_balancing_mode(
 ) -> impl IntoResponse {
     match state.service.set_load_balancing_mode(payload) {
         Ok(response) => Json(response).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// PUT /api/admin/config/admin-key
+/// 修改 Admin API Key（即时生效，旧 Key 立即失效）
+pub async fn update_admin_key(
+    State(state): State<AdminState>,
+    Json(payload): Json<UpdateApiKeyRequest>,
+) -> impl IntoResponse {
+    match state.service.update_admin_api_key(&payload.key) {
+        Ok(()) => Json(SuccessResponse::new("Admin API Key 已更新")).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// PUT /api/admin/config/client-key
+/// 修改客户端 API Key（即时生效）
+pub async fn update_client_key(
+    State(state): State<AdminState>,
+    Json(payload): Json<UpdateApiKeyRequest>,
+) -> impl IntoResponse {
+    match state.service.update_client_api_key(&payload.key) {
+        Ok(()) => Json(ApiKeyResponse {
+            success: true,
+            message: "客户端 API Key 已更新".to_string(),
+            api_key: payload.key.trim().to_string(),
+        })
+        .into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// POST /api/admin/config/client-key/generate
+/// 随机生成并应用一个新的客户端 API Key（即时生效）
+pub async fn generate_client_key(State(state): State<AdminState>) -> impl IntoResponse {
+    let new_key = crate::admin::AdminService::generate_client_api_key();
+    match state.service.update_client_api_key(&new_key) {
+        Ok(()) => Json(ApiKeyResponse {
+            success: true,
+            message: "已生成新的客户端 API Key".to_string(),
+            api_key: new_key,
+        })
+        .into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
 }

--- a/src/admin/middleware.rs
+++ b/src/admin/middleware.rs
@@ -1,6 +1,6 @@
 //! Admin API 中间件
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use axum::{
     body::Body,
@@ -17,16 +17,16 @@ use crate::common::auth;
 /// Admin API 共享状态
 #[derive(Clone)]
 pub struct AdminState {
-    /// Admin API 密钥
-    pub admin_api_key: String,
+    /// Admin API 密钥（使用 RwLock 包裹以支持运行时修改）
+    pub admin_api_key: Arc<RwLock<String>>,
     /// Admin 服务
     pub service: Arc<AdminService>,
 }
 
 impl AdminState {
-    pub fn new(admin_api_key: impl Into<String>, service: AdminService) -> Self {
+    pub fn new(admin_api_key: Arc<RwLock<String>>, service: AdminService) -> Self {
         Self {
-            admin_api_key: admin_api_key.into(),
+            admin_api_key,
             service: Arc::new(service),
         }
     }
@@ -38,13 +38,17 @@ pub async fn admin_auth_middleware(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    let api_key = auth::extract_api_key(&request);
+    let matched = match state.admin_api_key.read() {
+        Ok(key) => auth::extract_api_key(&request)
+            .map(|k| auth::constant_time_eq(&k, &key))
+            .unwrap_or(false),
+        Err(_) => false,
+    };
 
-    match api_key {
-        Some(key) if auth::constant_time_eq(&key, &state.admin_api_key) => next.run(request).await,
-        _ => {
-            let error = AdminErrorResponse::authentication_error();
-            (StatusCode::UNAUTHORIZED, Json(error)).into_response()
-        }
+    if matched {
+        next.run(request).await
+    } else {
+        let error = AdminErrorResponse::authentication_error();
+        (StatusCode::UNAUTHORIZED, Json(error)).into_response()
     }
 }

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -2,14 +2,15 @@
 
 use axum::{
     Router, middleware,
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
 };
 
 use super::{
     handlers::{
-        add_credential, delete_credential, force_refresh_token, get_all_credentials,
-        get_credential_balance, get_load_balancing_mode, reset_failure_count,
+        add_credential, delete_credential, force_refresh_token, generate_client_key,
+        get_all_credentials, get_credential_balance, get_load_balancing_mode, reset_failure_count,
         set_credential_disabled, set_credential_priority, set_load_balancing_mode,
+        update_admin_key, update_client_key,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -48,6 +49,9 @@ pub fn create_admin_router(state: AdminState) -> Router {
             "/config/load-balancing",
             get(get_load_balancing_mode).put(set_load_balancing_mode),
         )
+        .route("/config/admin-key", put(update_admin_key))
+        .route("/config/client-key", put(update_client_key))
+        .route("/config/client-key/generate", post(generate_client_key))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             admin_auth_middleware,

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use chrono::Utc;
 use parking_lot::Mutex;
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::kiro::model::credentials::KiroCredentials;
 use crate::kiro::token_manager::MultiTokenManager;
+use crate::model::config::Config;
 
 use super::error::AdminServiceError;
 use super::types::{
@@ -38,6 +39,10 @@ pub struct AdminService {
     cache_path: Option<PathBuf>,
     /// 已注册的端点名称集合（用于 add_credential 校验）
     known_endpoints: HashSet<String>,
+    /// 客户端 API Key 的共享句柄（与 Anthropic 认证中间件共享，支持运行时修改）
+    client_api_key: Option<Arc<RwLock<String>>>,
+    /// Admin API Key 的共享句柄（与 Admin 认证中间件共享，支持运行时修改）
+    admin_api_key: Option<Arc<RwLock<String>>>,
 }
 
 impl AdminService {
@@ -56,7 +61,20 @@ impl AdminService {
             balance_cache: Mutex::new(balance_cache),
             cache_path,
             known_endpoints: known_endpoints.into_iter().collect(),
+            client_api_key: None,
+            admin_api_key: None,
         }
+    }
+
+    /// 注入共享的 API Key 句柄，使 Admin API 能在运行时修改密钥
+    pub fn with_shared_keys(
+        mut self,
+        client_api_key: Arc<RwLock<String>>,
+        admin_api_key: Arc<RwLock<String>>,
+    ) -> Self {
+        self.client_api_key = Some(client_api_key);
+        self.admin_api_key = Some(admin_api_key);
+        self
     }
 
     /// 获取所有凭据状态
@@ -297,6 +315,86 @@ impl AdminService {
             .map_err(|e| AdminServiceError::InternalError(e.to_string()))?;
 
         Ok(LoadBalancingModeResponse { mode: req.mode })
+    }
+
+    /// 生成一个随机的客户端 API Key（格式：sk-kiro-<32位十六进制>）
+    pub fn generate_client_api_key() -> String {
+        let hex: String = (0..32)
+            .map(|_| {
+                let n = fastrand::u8(0..16);
+                std::char::from_digit(n as u32, 16).unwrap()
+            })
+            .collect();
+        format!("sk-kiro-{hex}")
+    }
+
+    /// 修改客户端 API Key：持久化到 config.json 并即时更新运行时认证
+    pub fn update_client_api_key(&self, new_key: &str) -> Result<(), AdminServiceError> {
+        let new_key = new_key.trim();
+        if new_key.is_empty() {
+            return Err(AdminServiceError::InvalidCredential(
+                "API Key 不能为空".to_string(),
+            ));
+        }
+
+        self.persist_config_field(|config| config.api_key = Some(new_key.to_string()))?;
+
+        if let Some(handle) = &self.client_api_key {
+            if let Ok(mut guard) = handle.write() {
+                *guard = new_key.to_string();
+            }
+        }
+
+        tracing::info!("客户端 API Key 已更新");
+        Ok(())
+    }
+
+    /// 修改 Admin API Key：持久化到 config.json 并即时更新运行时认证
+    pub fn update_admin_api_key(&self, new_key: &str) -> Result<(), AdminServiceError> {
+        let new_key = new_key.trim();
+        if new_key.is_empty() {
+            return Err(AdminServiceError::InvalidCredential(
+                "Admin API Key 不能为空".to_string(),
+            ));
+        }
+
+        self.persist_config_field(|config| config.admin_api_key = Some(new_key.to_string()))?;
+
+        if let Some(handle) = &self.admin_api_key {
+            if let Ok(mut guard) = handle.write() {
+                *guard = new_key.to_string();
+            }
+        }
+
+        tracing::info!("Admin API Key 已更新");
+        Ok(())
+    }
+
+    /// 重新加载磁盘上的 config.json，应用修改后写回（参考 persist_load_balancing_mode）
+    fn persist_config_field(
+        &self,
+        apply: impl FnOnce(&mut Config),
+    ) -> Result<(), AdminServiceError> {
+        let config_path = self
+            .token_manager
+            .config()
+            .config_path()
+            .map(|p| p.to_path_buf())
+            .ok_or_else(|| {
+                AdminServiceError::InternalError(
+                    "配置文件路径未知，无法持久化修改".to_string(),
+                )
+            })?;
+
+        let mut config = Config::load(&config_path).map_err(|e| {
+            AdminServiceError::InternalError(format!("重新加载配置失败: {e}"))
+        })?;
+        apply(&mut config);
+        config
+            .save()
+            .map_err(|e| AdminServiceError::InternalError(format!("写入配置文件失败: {e}")))?;
+
+        Ok(())
     }
 
     /// 强制刷新指定凭据的 Token

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -196,6 +196,26 @@ pub struct SetLoadBalancingModeRequest {
     pub mode: String,
 }
 
+// ============ API Key 管理 ============
+
+/// 修改 API Key 请求（客户端 Key 或 Admin Key）
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateApiKeyRequest {
+    /// 新的 API Key
+    pub key: String,
+}
+
+/// 修改/生成客户端 API Key 的响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeyResponse {
+    pub success: bool,
+    pub message: String,
+    /// 新的明文 API Key（仅在生成或修改成功时返回一次）
+    pub api_key: String,
+}
+
 // ============ 通用响应 ============
 
 /// 操作成功响应

--- a/src/anthropic/middleware.rs
+++ b/src/anthropic/middleware.rs
@@ -1,6 +1,6 @@
 //! Anthropic API 中间件
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use axum::{
     body::Body,
@@ -18,8 +18,8 @@ use super::types::ErrorResponse;
 /// 应用共享状态
 #[derive(Clone)]
 pub struct AppState {
-    /// API 密钥
-    pub api_key: String,
+    /// API 密钥（使用 RwLock 包裹以支持运行时修改）
+    pub api_key: Arc<RwLock<String>>,
     /// Kiro Provider（可选，用于实际 API 调用）
     /// 内部使用 MultiTokenManager，已支持线程安全的多凭据管理
     pub kiro_provider: Option<Arc<KiroProvider>>,
@@ -28,10 +28,12 @@ pub struct AppState {
 }
 
 impl AppState {
-    /// 创建新的应用状态
-    pub fn new(api_key: impl Into<String>, extract_thinking: bool) -> Self {
+    /// 使用共享的 API Key 句柄创建应用状态
+    ///
+    /// 用于让 Admin API 能在运行时修改同一个 API Key
+    pub fn with_shared_api_key(api_key: Arc<RwLock<String>>, extract_thinking: bool) -> Self {
         Self {
-            api_key: api_key.into(),
+            api_key,
             kiro_provider: None,
             extract_thinking,
         }
@@ -50,12 +52,18 @@ pub async fn auth_middleware(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    match auth::extract_api_key(&request) {
-        Some(key) if auth::constant_time_eq(&key, &state.api_key) => next.run(request).await,
-        _ => {
-            let error = ErrorResponse::authentication_error();
-            (StatusCode::UNAUTHORIZED, Json(error)).into_response()
-        }
+    let matched = match state.api_key.read() {
+        Ok(key) => auth::extract_api_key(&request)
+            .map(|k| auth::constant_time_eq(&k, &key))
+            .unwrap_or(false),
+        Err(_) => false,
+    };
+
+    if matched {
+        next.run(request).await
+    } else {
+        let error = ErrorResponse::authentication_error();
+        (StatusCode::UNAUTHORIZED, Json(error)).into_response()
     }
 }
 

--- a/src/anthropic/router.rs
+++ b/src/anthropic/router.rs
@@ -1,5 +1,7 @@
 //! Anthropic API 路由配置
 
+use std::sync::{Arc, RwLock};
+
 use axum::{
     Router,
     extract::DefaultBodyLimit,
@@ -30,16 +32,16 @@ const MAX_BODY_SIZE: usize = 50 * 1024 * 1024;
 /// - `Authorization: Bearer <token>` header
 ///
 /// # 参数
-/// - `api_key`: API 密钥，用于验证客户端请求
+/// - `api_key`: 共享的 API 密钥句柄，用于验证客户端请求（支持运行时修改）
 /// - `kiro_provider`: 可选的 KiroProvider，用于调用上游 API
 
 /// 创建带有 KiroProvider 的 Anthropic API 路由
 pub fn create_router_with_provider(
-    api_key: impl Into<String>,
+    api_key: Arc<RwLock<String>>,
     kiro_provider: Option<KiroProvider>,
     extract_thinking: bool,
 ) -> Router {
-    let mut state = AppState::new(api_key, extract_thinking);
+    let mut state = AppState::with_shared_api_key(api_key, extract_thinking);
     if let Some(provider) = kiro_provider {
         state = state.with_kiro_provider(provider);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ async fn main() {
         std::process::exit(1);
     });
 
+    // 客户端 API Key 的共享句柄（Anthropic 认证与 Admin 修改共用，支持运行时即时生效）
+    let shared_api_key = std::sync::Arc::new(std::sync::RwLock::new(api_key.clone()));
+
     // 构建代理配置
     let proxy_config = config.proxy_url.as_ref().map(|url| {
         let mut proxy = http_client::ProxyConfig::new(url);
@@ -159,7 +162,7 @@ async fn main() {
 
     // 构建 Anthropic API 路由（profile_arn 由 provider 层根据实际凭据动态注入）
     let anthropic_app = anthropic::create_router_with_provider(
-        &api_key,
+        shared_api_key.clone(),
         Some(kiro_provider),
         config.extract_thinking,
     );
@@ -177,9 +180,13 @@ async fn main() {
             tracing::warn!("admin_api_key 配置为空，Admin API 未启用");
             anthropic_app
         } else {
+            // Admin API Key 的共享句柄（支持运行时即时修改）
+            let shared_admin_key =
+                std::sync::Arc::new(std::sync::RwLock::new(admin_key.clone()));
             let admin_service =
-                admin::AdminService::new(token_manager.clone(), endpoint_names.clone());
-            let admin_state = admin::AdminState::new(admin_key, admin_service);
+                admin::AdminService::new(token_manager.clone(), endpoint_names.clone())
+                    .with_shared_keys(shared_api_key.clone(), shared_admin_key.clone());
+            let admin_state = admin::AdminState::new(shared_admin_key, admin_service);
             let admin_app = admin::create_admin_router(admin_state);
 
             // 创建 Admin UI 路由


### PR DESCRIPTION
## 功能

在 Admin 管理面板中新增修改两类密钥的能力，修改后**即时生效、无需重启服务**，并持久化到 config.json：

- **管理员密码（adminApiKey）**：右上角齿轮按钮打开弹窗，输入并确认新密码。修改后当前会话自动提示重新登录。
- **客户端 API Key（apiKey）**：凭据管理区新增「修改 API Key」按钮，弹窗支持手动输入或一键随机生成 `sk-kiro-<32位hex>`，并提供复制按钮。

## 实现

**后端**

- 将认证用的 `apiKey` / `adminApiKey` 从启动时定死的 `String` 改为 `Arc<RwLock<String>>` 共享句柄，认证中间件读锁取值，Admin 写操作更新同一句柄，从而运行时即时生效。
- 持久化复用现有 `Config::load → 改字段 → save()` 模式（参考 `persist_load_balancing_mode`）。
- 新增 3 个端点，均受 `admin_auth_middleware` 保护：
  - `PUT  /api/admin/config/admin-key`
  - `PUT  /api/admin/config/client-key`
  - `POST /api/admin/config/client-key/generate`
- 随机 key 使用项目已有的 `fastrand` 生成。

**前端**

- 新增 `admin-key-dialog` 与 `client-key-dialog` 两个弹窗组件及对应 API/类型。

## 安全

- 生成/修改的明文 key 仅在响应里返回一次，列表展示仍用现有 `maskedApiKey` 脱敏。
- 拒绝空 key。
- 修改管理员密码后旧 key 立即失效，前端主动更新本地 token 并提示重新登录。

## 测试

- 后端 `cargo build --release` 通过。
- 前端用 mock 数据预览了两个弹窗的完整交互（输入、随机生成、复制、保存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)