### PR TITLE
feat(models): 增加对 GPT-5.6 Sol/Terra/Luna 的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **Thinking 模式**: 支持 Claude 的 extended thinking 功能
 - **工具调用**: 完整支持 function calling / tool use
 - **WebSearch**: 内置 WebSearch 工具转换逻辑
-- **多模型支持**: 支持 Sonnet、Opus、Haiku 系列模型
+- **多模型支持**: 支持 Sonnet、Opus、Haiku 系列模型，以及 GPT-5.6 Sol/Terra/Luna
 - **Admin 管理**: 可选的 Web 管理界面和 API，支持凭据管理、余额查询等
 - **多级 Region 配置**: 支持全局和凭据级别的 Auth Region / API Region 配置
 - **凭据级代理**: 支持为每个凭据单独配置 HTTP/SOCKS5 代理，优先级：凭据代理 > 全局代理 > 无代理
@@ -435,8 +435,11 @@ RUST_LOG=debug ./target/release/kiro-rs
 
 ## 模型映射
 
-| Anthropic 模型 | Kiro 模型 |
-|----------------|-----------|
+| 客户端模型 | Kiro 上游模型 |
+|-----------|--------------|
+| `*gpt-5.6*sol*` / `gpt-5-6-sol` / `openai.gpt-5.6-sol` | `gpt-5.6-sol` |
+| `*gpt-5.6*terra*` / `gpt-5-6-terra` / `openai.gpt-5.6-terra` | `gpt-5.6-terra` |
+| `*gpt-5.6*luna*` / `gpt-5-6-luna` / `openai.gpt-5.6-luna` | `gpt-5.6-luna` |
 | `*sonnet-5*` | `claude-sonnet-5` |
 | `*sonnet*`（含 4.6/4-6） | `claude-sonnet-4.6` |
 | `*sonnet*`（含 4.5/4-5） | `claude-sonnet-4.5` |
@@ -445,6 +448,8 @@ RUST_LOG=debug ./target/release/kiro-rs
 | `*opus*`（含 4.6/4-6） | `claude-opus-4.6` |
 | `*opus*`（含 4.5/4-5） | `claude-opus-4.5` |
 | `*haiku*` | `claude-haiku-4.5` |
+
+GPT-5.6 系列（Sol / Terra / Luna）于 2026-07-13 在 Kiro 上线，状态为 Experimental，上下文窗口 272K，仅 `us-east-1` / `eu-central-1` 可用。上游使用 hidden chain-of-thought，**不提供** Claude 风格的 `-thinking` 后缀或 effort 级别。
 
 Sonnet 5 的 thinking 行为与已知限制见 [docs/claude-sonnet-5.md](docs/claude-sonnet-5.md)。
 

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -75,10 +75,36 @@ Never suggest bypassing these limits via alternative tools. \
 Never ask the user whether to switch approaches. \
 Complete all chunked operations without commentary.";
 
-/// 模型映射：将 Anthropic 模型名映射到 Kiro 模型 ID
+/// 将 GPT 模型名映射到 Kiro 上游 wire ID（`gpt-5.6-{sol,terra,luna}`）
+fn map_gpt_model(model_lower: &str) -> Option<String> {
+    let model_lower = model_lower.strip_prefix("openai.").unwrap_or(model_lower);
+    let normalized = model_lower.replace("gpt-5-6", "gpt-5.6");
+
+    if !normalized.contains("gpt-5.6") {
+        return None;
+    }
+
+    if normalized.contains("sol") {
+        return Some("gpt-5.6-sol".to_string());
+    }
+    if normalized.contains("terra") {
+        return Some("gpt-5.6-terra".to_string());
+    }
+    if normalized.contains("luna") {
+        return Some("gpt-5.6-luna".to_string());
+    }
+
+    None
+}
+
+/// 模型映射：将 Anthropic / OpenAI 模型名映射到 Kiro 模型 ID
 /// 严格对照版本号
 pub fn map_model(model: &str) -> Option<String> {
     let model_lower = model.to_lowercase();
+
+    if let Some(mapped) = map_gpt_model(&model_lower) {
+        return Some(mapped);
+    }
 
     if model_lower.contains("sonnet") {
         if model_lower.contains("sonnet-5") {
@@ -113,9 +139,10 @@ pub fn map_model(model: &str) -> Option<String> {
 ///
 /// 复用 `map_model` 的映射逻辑，确保窗口大小判断与模型映射一致。
 /// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
-/// Sonnet 5 / Opus 4.7 / 4.8 同 1M
+/// Sonnet 5 / Opus 4.7 / 4.8 同 1M；GPT-5.6 系列为 272K
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
+        Some(mapped) if mapped.starts_with("gpt-5.6-") => 272_000,
         Some(mapped) if mapped == "claude-sonnet-5" || mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" || mapped == "claude-opus-4.8" => 1_000_000,
         _ => 200_000,
     }
@@ -935,6 +962,33 @@ mod tests {
     #[test]
     fn test_map_model_unsupported() {
         assert!(map_model("gpt-4").is_none());
+        assert!(map_model("gpt-4o").is_none());
+    }
+
+    #[test]
+    fn test_map_model_gpt56() {
+        assert_eq!(
+            map_model("gpt-5.6-sol"),
+            Some("gpt-5.6-sol".to_string())
+        );
+        assert_eq!(
+            map_model("gpt-5.6-terra"),
+            Some("gpt-5.6-terra".to_string())
+        );
+        assert_eq!(
+            map_model("gpt-5.6-luna"),
+            Some("gpt-5.6-luna".to_string())
+        );
+        assert_eq!(
+            map_model("gpt-5-6-sol"),
+            Some("gpt-5.6-sol".to_string())
+        );
+        assert_eq!(
+            map_model("openai.gpt-5.6-terra"),
+            Some("gpt-5.6-terra".to_string())
+        );
+        assert_eq!(get_context_window_size("gpt-5.6-sol"), 272_000);
+        assert_eq!(get_context_window_size("gpt-5.6-luna"), 272_000);
     }
 
     #[test]

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -75,6 +75,33 @@ pub async fn get_models() -> impl IntoResponse {
 
     let models = vec![
         Model {
+            id: "gpt-5.6-sol".to_string(),
+            object: "model".to_string(),
+            created: 1783900800, // Jul 13, 2026
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Sol".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
+            id: "gpt-5.6-terra".to_string(),
+            object: "model".to_string(),
+            created: 1783900800, // Jul 13, 2026
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Terra".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
+            id: "gpt-5.6-luna".to_string(),
+            object: "model".to_string(),
+            created: 1783900800, // Jul 13, 2026
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Luna".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
             id: "claude-sonnet-5".to_string(),
             object: "model".to_string(),
             created: 1782777600, // Jun 30, 2026


### PR DESCRIPTION
As #190 requested, I've implemented GPT models.

## Summary
- 适配 Kiro 新上线的 GPT-5.6 Sol / Terra / Luna（上游 wire ID：`gpt-5.6-{sol,terra,luna}`）
- 在 `map_model` 中支持直通与别名（`gpt-5-6-*`、`openai.gpt-5.6-*`），上下文窗口设为 272K
- 更新 `GET /v1/models` 与 README 模型映射说明（无 Claude 风格 `-thinking` / effort）

## Test plan
- [x] `cargo test --no-default-features map_model_gpt`（`test_map_model_gpt56` 通过）
- [x] `test_map_model_gpt56` 覆盖 sol/terra/luna、横杠别名、Bedrock 前缀与上下文窗口
- [ ] （可选）用有效凭据 `--probe-events --probe-model gpt-5.6-sol` 做上游冒烟