### PR TITLE
feat(anthropic): 增加对 Claude Opus 5 的支持 (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ RUST_LOG=debug ./target/release/kiro-rs
 | `*sonnet-5*` | `claude-sonnet-5` |
 | `*sonnet*`（含 4.6/4-6） | `claude-sonnet-4.6` |
 | `*sonnet*`（含 4.5/4-5） | `claude-sonnet-4.5` |
+| `*opus-5*` | `claude-opus-5` |
 | `*opus*`（含 4.8/4-8） | `claude-opus-4.8` |
 | `*opus*`（含 4.7/4-7） | `claude-opus-4.7` |
 | `*opus*`（含 4.6/4-6） | `claude-opus-4.6` |

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -91,7 +91,9 @@ pub fn map_model(model: &str) -> Option<String> {
             None
         }
     } else if model_lower.contains("opus") {
-        if model_lower.contains("4-5") || model_lower.contains("4.5") {
+        if model_lower.contains("opus-5") {
+            Some("claude-opus-5".to_string())
+        } else if model_lower.contains("4-5") || model_lower.contains("4.5") {
             Some("claude-opus-4.5".to_string())
         } else if model_lower.contains("4-6") || model_lower.contains("4.6") {
             Some("claude-opus-4.6".to_string())
@@ -113,10 +115,10 @@ pub fn map_model(model: &str) -> Option<String> {
 ///
 /// 复用 `map_model` 的映射逻辑，确保窗口大小判断与模型映射一致。
 /// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
-/// Sonnet 5 / Opus 4.7 / 4.8 同 1M
+/// Sonnet 5 / Opus 4.7 / 4.8 / Opus 5 同 1M
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
-        Some(mapped) if mapped == "claude-sonnet-5" || mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" || mapped == "claude-opus-4.8" => 1_000_000,
+        Some(mapped) if mapped == "claude-sonnet-5" || mapped == "claude-opus-5" || mapped == "claude-sonnet-4.6" || mapped == "claude-opus-4.6" || mapped == "claude-opus-4.7" || mapped == "claude-opus-4.8" => 1_000_000,
         _ => 200_000,
     }
 }
@@ -973,6 +975,24 @@ mod tests {
         assert_eq!(
             map_model("claude-sonnet-4-5-20250929"),
             Some("claude-sonnet-4.5".to_string())
+        );
+    }
+
+    #[test]
+    fn test_map_model_opus_5() {
+        assert_eq!(
+            map_model("claude-opus-5"),
+            Some("claude-opus-5".to_string())
+        );
+        assert_eq!(
+            map_model("claude-opus-5-thinking"),
+            Some("claude-opus-5".to_string())
+        );
+        assert_eq!(get_context_window_size("claude-opus-5"), 1_000_000);
+        // opus-4-5 不应误匹配为 opus-5
+        assert_eq!(
+            map_model("claude-opus-4-5-20251101"),
+            Some("claude-opus-4.5".to_string())
         );
     }
 

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -75,6 +75,24 @@ pub async fn get_models() -> impl IntoResponse {
 
     let models = vec![
         Model {
+            id: "claude-opus-5".to_string(),
+            object: "model".to_string(),
+            created: 1782777600, // Jun 30, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 5".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
+            id: "claude-opus-5-thinking".to_string(),
+            object: "model".to_string(),
+            created: 1782777600, // Jun 30, 2026
+            owned_by: "anthropic".to_string(),
+            display_name: "Claude Opus 5 (Thinking)".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 128_000,
+        },
+        Model {
             id: "claude-sonnet-5".to_string(),
             object: "model".to_string(),
             created: 1782777600, // Jun 30, 2026
@@ -687,7 +705,8 @@ fn override_thinking_from_model_name(payload: &mut MessagesRequest) {
 
     let is_adaptive_thinking = (model_lower.contains("opus")
         && (model_lower.contains("4-6") || model_lower.contains("4.6")))
-        || model_lower.contains("sonnet-5");
+        || model_lower.contains("sonnet-5")
+        || model_lower.contains("opus-5");
 
     let thinking_type = if is_adaptive_thinking {
         "adaptive"


### PR DESCRIPTION
## 概述

Closes #194

Kiro 已上线 `claude-opus-5`，本 PR 补齐模型映射、`/v1/models` 列表与 thinking 处理，行为与既有的 Claude Sonnet 5 支持（#184）保持一致，不改动模型解析的基础逻辑。

## 改动

- `map_model`：新增 `opus-5 -> claude-opus-5` 分支，置于 `4-5` 判断之前，避免 `opus-4-5` 被误匹配为 `opus-5`
- `get_context_window_size`：`claude-opus-5` 纳入 1M 上下文
- `/v1/models`：新增 `claude-opus-5` 与 `claude-opus-5-thinking`
- `override_thinking_from_model_name`：`opus-5` 归入 adaptive thinking（与 sonnet-5、opus-4.6 一致）
- 新增 `test_map_model_opus_5` 单测（含 `opus-4-5` 不误匹配断言）
- README：补充模型映射表

## 测试

在 aarch64 服务器上以项目自带 Dockerfile 构建镜像，用独立端口 + 独立配置起临时容器验证（不影响任何线上服务）：

- `GET /v1/models` 正确返回 `claude-opus-5` / `claude-opus-5-thinking`
- `claude-opus-5` 非流式：上游正常返回，HTTP 200
- `claude-opus-5-thinking`：正常返回，日志确认触发 `thinking_type="adaptive"`
- `claude-opus-5` 流式：`message_start -> content_block_* -> message_delta -> message_stop` 事件序列完整