### PR TITLE
fix(anthropic): 缩短超长工具名时同步替换提示词正文中的原名

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -267,6 +267,7 @@ pub fn convert_request(req: &MessagesRequest) -> Result<ConversionResult, Conver
     // 6. 转换工具定义（超长名称自动缩短并记录映射）
     let mut tool_name_map = HashMap::new();
     let mut tools = convert_tools(&req.tools, &mut tool_name_map);
+    let text_content = replace_long_tool_names(&text_content, &tool_name_map);
 
     // 7. 构建历史消息（需要先构建，以便收集历史中使用的工具）
     let mut history = build_history(req, messages, &model_id, &mut tool_name_map)?;
@@ -580,6 +581,15 @@ fn map_tool_name(name: &str, tool_name_map: &mut HashMap<String, String>) -> Str
     short
 }
 
+/// Replace original long tool names in prompt text with the aliases sent to Kiro.
+fn replace_long_tool_names(text: &str, tool_name_map: &HashMap<String, String>) -> String {
+    tool_name_map
+        .iter()
+        .fold(text.to_string(), |content, (short, original)| {
+            content.replace(original, short)
+        })
+}
+
 /// 转换工具定义
 fn convert_tools(tools: &Option<Vec<super::types::Tool>>, tool_name_map: &mut HashMap<String, String>) -> Vec<Tool> {
     let Some(tools) = tools else {
@@ -723,7 +733,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
         } else if msg.role == "assistant" {
             // 先处理累积的 user 消息
             if !user_buffer.is_empty() {
-                let merged_user = merge_user_messages(&user_buffer, model_id)?;
+                let merged_user = merge_user_messages(&user_buffer, model_id, tool_name_map)?;
                 history.push(Message::User(merged_user));
                 user_buffer.clear();
             }
@@ -740,7 +750,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
 
     // 处理结尾的孤立 user 消息
     if !user_buffer.is_empty() {
-        let merged_user = merge_user_messages(&user_buffer, model_id)?;
+        let merged_user = merge_user_messages(&user_buffer, model_id, tool_name_map)?;
         history.push(Message::User(merged_user));
 
         // 自动配对一个 "OK" 的 assistant 响应
@@ -755,6 +765,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
 fn merge_user_messages(
     messages: &[&super::types::Message],
     model_id: &str,
+    tool_name_map: &HashMap<String, String>,
 ) -> Result<HistoryUserMessage, ConversionError> {
     let mut content_parts = Vec::new();
     let mut all_images = Vec::new();
@@ -769,7 +780,7 @@ fn merge_user_messages(
         all_tool_results.extend(tool_results);
     }
 
-    let content = content_parts.join("\n");
+    let content = replace_long_tool_names(&content_parts.join("\n"), tool_name_map);
     // 保留文本内容，即使有工具结果也不丢弃用户文本
     let mut user_msg = UserMessage::new(&content, model_id);
 
@@ -1161,6 +1172,48 @@ mod tests {
         let tools = &result.conversation_state.current_message.user_input_message
             .user_input_message_context.tools;
         assert_eq!(tools[0].tool_specification.name, *short);
+    }
+
+    #[test]
+    fn test_long_tool_name_in_prompt_is_mapped() {
+        use super::super::types::{Message as AnthropicMessage, Tool as AnthropicTool};
+
+        let long_tool_name =
+            "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
+        let mut schema = std::collections::HashMap::new();
+        schema.insert("type".to_string(), serde_json::json!("object"));
+
+        let req = MessagesRequest {
+            model: "claude-opus-5".to_string(),
+            max_tokens: 1024,
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: serde_json::json!(format!("Call {long_tool_name} now.")),
+            }],
+            system: None,
+            stream: false,
+            tools: Some(vec![AnthropicTool {
+                name: long_tool_name.to_string(),
+                description: "A test tool".to_string(),
+                input_schema: schema,
+                tool_type: None,
+                max_uses: None,
+            }]),
+            thinking: None,
+            tool_choice: None,
+            output_config: None,
+            metadata: None,
+        };
+
+        let result = convert_request(&req).unwrap();
+        let short_name = result.tool_name_map.keys().next().unwrap();
+        let content = &result
+            .conversation_state
+            .current_message
+            .user_input_message
+            .content;
+        assert!(content.contains(short_name));
+        assert!(!content.contains(long_tool_name));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

`map_tool_name()` 会把超过 `TOOL_NAME_MAX_LEN`(63) 的工具名换成「54 字符前缀 + `_` + sha256 前 8 位」的短名，并在 `tool_name_map` 里记下 short → original。工具**定义**因此发给 Kiro 的是短名。

但提示词正文（`text_content`）和 `merge_user_messages()` 合并出来的 user 消息里，工具名仍然是**原始长名**。于是模型看到的是：

- 正文说「调用 `mcp__plugin_cloudflare_cloudflare-docs__search_cloudflare_documentation`」
- 可用工具列表里却只有 `mcp__plugin_cloudflare_cloudflare-docs__search_cloudflare_d_1a2b3c4d`

模型据正文发起调用，得到的是一个未注册的工具名，表现为工具调用失败或凭空编造名称，而且没有明确报错，排查起来很费劲。

MCP 工具名是 `mcp__<server>__<tool>` 形式，超过 63 字符非常常见 —— 实际使用中每轮请求都会有若干个工具命中缩短逻辑。

## 修复

新增 `replace_long_tool_names()`，按 `tool_name_map` 把正文里出现的原始长名替换成实际发给 Kiro 的短名，在两处调用：

- `convert_request()` —— 当前轮的 `text_content`
- `merge_user_messages()` —— 历史 user 消息合并后的正文

`merge_user_messages()` 因此需要多接一个 `&HashMap<String, String>` 参数，两个调用点同步更新。

## 测试

新增 `test_long_tool_name_in_prompt_is_mapped`：构造一个 66 字符的工具名并在 user 消息正文里引用它，断言转换后正文里出现的是短名。

`cargo test --no-default-features` 结果：

| | passed | failed |
|---|---|---|
| master (`5ca5703`) | 200 | 8 |
| 本 PR | 201 | 8 |

失败的 8 个在 master 上就已经是红的，与本 PR 无关 —— 都是 `test_map_model_*` / `test_tool_name_mapping_*` 这类 fixture 里还在用 `claude-sonnet-4` / `claude-opus-4-20250514` 等已不再支持的模型别名，`map_model()` 返回 `UnsupportedModel` 导致 unwrap panic。需要的话我可以另开一个 PR 单独修 fixture。

`cargo fmt --check` 的输出与 master 逐条一致，本 PR 没有引入新的格式差异。
